### PR TITLE
Add parallel agent orchestrator and CLI entrypoint

### DIFF
--- a/dashboard/app/api/dev/agent/parallel/route.ts
+++ b/dashboard/app/api/dev/agent/parallel/route.ts
@@ -1,0 +1,33 @@
+import { runParallelAgentTask } from '../../../../../../src/server/agent/parallelAgentService';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body.task !== 'string' || body.task.trim().length === 0) {
+      return new Response(JSON.stringify({ error: 'Missing task in request body' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    const result = await runParallelAgentTask({
+      task: body.task,
+      repoPath: typeof body.repoPath === 'string' ? body.repoPath : undefined
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Parallel agent failed unexpectedly';
+    console.error('Parallel agent API error', message);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}

--- a/docs/dev/agents.md
+++ b/docs/dev/agents.md
@@ -1,0 +1,31 @@
+# Parallel Agent Orchestrator
+
+The parallel agent orchestrator coordinates multiple browser-agent subtasks in parallel to speed up planning and implementation for a high-level request.
+
+## What it does
+- Splits an input task into research, spec, and code subtasks.
+- Executes those subtasks concurrently using the existing browser agent service.
+- Aggregates summaries, logs, and any generated artifacts.
+
+## API usage
+Send a POST request to the dev endpoint with your task description:
+
+```
+POST /api/dev/agent/parallel
+Content-Type: application/json
+{
+  "task": "Describe the high-level task you want",
+  "repoPath": "/absolute/path/to/repo" // optional
+}
+```
+
+## CLI usage
+Ensure the dev server is running at `http://localhost:3000`, then run:
+
+```
+pnpm agent:parallel "Add a FHIR MedicationRequest endpoint that wires into IPrescribe and our EMR's existing patient model"
+pnpm agent:parallel "Add a YouTubeService that syncs channel metrics nightly into our Marketing Studio dashboard"
+pnpm agent:parallel "Refactor Morning Briefing to include operations/compliance alerts and restructure prompts for Gemini/Vertex"
+```
+
+Artifacts returned by the parallel agent are written to disk relative to your repository root.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "clean:git": "git clean -fd",
     "preview": "vite preview",
     "electron": "tsx electron/main.ts",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "agent": "ts-node tools/agent-cli.ts",
+    "agent:parallel": "ts-node tools/agent-parallel-cli.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/src/server/agent/browserAgentService.ts
+++ b/src/server/agent/browserAgentService.ts
@@ -1,0 +1,36 @@
+export type BrowserAgentInput = {
+  task: string;
+  repoPath?: string;
+};
+
+export type BrowserAgentArtifact = {
+  path: string;
+  content: string;
+};
+
+export type BrowserAgentResult = {
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+};
+
+/**
+ * Placeholder browser agent implementation.
+ * In a full deployment, this should delegate to the browser automation layer
+ * to execute the requested task. For now we return a structured response so
+ * orchestrators and API consumers can build on top of it.
+ */
+export async function runBrowserAgentTask(
+  input: BrowserAgentInput
+): Promise<BrowserAgentResult> {
+  const logs = [`Received task: ${input.task}`];
+  if (input.repoPath) {
+    logs.push(`Using repository path: ${input.repoPath}`);
+  }
+
+  return {
+    summary: `Executed browser agent task: ${input.task}`,
+    artifacts: [],
+    logs
+  };
+}

--- a/src/server/agent/parallelAgentService.ts
+++ b/src/server/agent/parallelAgentService.ts
@@ -1,0 +1,110 @@
+import {
+  runBrowserAgentTask,
+  type BrowserAgentArtifact,
+  type BrowserAgentResult
+} from './browserAgentService';
+
+export type ParallelAgentInput = {
+  task: string;
+  repoPath?: string;
+};
+
+export type ParallelAgentSubtaskResult = {
+  name: string;
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+};
+
+export type ParallelAgentResult = {
+  summary: string;
+  subtasks: ParallelAgentSubtaskResult[];
+  artifacts: BrowserAgentArtifact[];
+  logs: string[];
+};
+
+async function executeSubtask(
+  name: string,
+  description: string,
+  repoPath?: string
+): Promise<ParallelAgentSubtaskResult> {
+  try {
+    const result: BrowserAgentResult = await runBrowserAgentTask({
+      task: description,
+      repoPath
+    });
+
+    return {
+      name,
+      summary: result.summary,
+      artifacts: result.artifacts || [],
+      logs: result.logs || []
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error executing subtask';
+    return {
+      name,
+      summary: `Failed: ${message}`,
+      artifacts: [],
+      logs: [message]
+    };
+  }
+}
+
+export async function runParallelAgentTask(
+  input: ParallelAgentInput
+): Promise<ParallelAgentResult> {
+  const { task, repoPath } = input;
+  const orchestratorLogs: string[] = [];
+
+  const researchDescription =
+    'Research external docs + our codebase context needed to accomplish: ' +
+    task +
+    '. Focus on APIs, integrations, and constraints. Return a structured summary and suggestions.';
+
+  const specDescription =
+    'Generate a concise technical spec and file-level plan for: ' +
+    task +
+    '. Use any relevant context from our EMR architecture (modules, MCP tools, FHIR, Rupa, IPrescribe, etc.).';
+
+  const codeDescription =
+    'Draft code artifacts or patches to implement: ' +
+    task +
+    ' based on the planned spec. Prefer TypeScript and our existing patterns. Include paths and file content.';
+
+  const [researchResult, specResult, codeResult] = await Promise.all([
+    executeSubtask('research', researchDescription, repoPath),
+    executeSubtask('spec', specDescription, repoPath),
+    executeSubtask('code', codeDescription, repoPath)
+  ]);
+
+  const subtasks = [researchResult, specResult, codeResult];
+  const artifactsMap = new Map<string, BrowserAgentArtifact>();
+
+  for (const subtask of subtasks) {
+    for (const artifact of subtask.artifacts || []) {
+      artifactsMap.set(artifact.path, artifact);
+    }
+  }
+
+  const artifacts = Array.from(artifactsMap.values());
+  orchestratorLogs.push(
+    `Subtasks completed: ${subtasks.length}. Artifacts generated: ${artifacts.length}.`
+  );
+
+  const failed = subtasks.filter((subtask) => subtask.summary.startsWith('Failed'));
+  const summaryParts = [
+    failed.length === 0
+      ? 'All subtasks succeeded.'
+      : `${failed.length} subtasks failed: ${failed.map((f) => f.name).join(', ')}.`,
+    `Total artifacts: ${artifacts.length}.`
+  ];
+
+  return {
+    summary: summaryParts.join(' '),
+    subtasks,
+    artifacts,
+    logs: orchestratorLogs
+  };
+}

--- a/tools/agent-cli.ts
+++ b/tools/agent-cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env ts-node
+
+console.error('The single-agent CLI is not configured in this repository. Use "pnpm agent:parallel \"<task>\"" instead.');
+process.exit(1);

--- a/tools/agent-parallel-cli.ts
+++ b/tools/agent-parallel-cli.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env ts-node
+
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+const [,, ...args] = process.argv;
+const task = args.join(' ').trim();
+
+if (!task) {
+  console.error('Usage: agent:parallel "<task description>"');
+  process.exit(1);
+}
+
+const repoPath = process.cwd();
+const endpoint = 'http://localhost:3000/api/dev/agent/parallel';
+
+async function main() {
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task, repoPath })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Request failed with status ${response.status}: ${errorText}`);
+    }
+
+    const result = await response.json();
+
+    console.log('=== Parallel Agent Summary ===');
+    console.log(result.summary);
+    console.log('\n=== Subtasks ===');
+    for (const subtask of result.subtasks || []) {
+      console.log(`- ${subtask.name}: ${subtask.summary}`);
+    }
+
+    console.log('\n=== Generated Artifacts ===');
+    for (const artifact of result.artifacts || []) {
+      const filePath = path.join(repoPath, artifact.path);
+      const dirPath = path.dirname(filePath);
+      mkdirSync(dirPath, { recursive: true });
+      writeFileSync(filePath, artifact.content, 'utf-8');
+      console.log(`Wrote ${filePath}`);
+    }
+
+    if (result.logs && result.logs.length > 0) {
+      console.log('\n=== Logs ===');
+      for (const log of result.logs) {
+        console.log(`- ${log}`);
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Parallel agent failed:', message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a browser agent service placeholder and a new parallel agent orchestrator
- expose the orchestrator through a dev API route and a CLI command for local use
- document parallel agent usage for developers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfb8a564483249c7fb5f912b3fee3)