### PR TITLE
Add dev agent orchestration and CLIs

### DIFF
--- a/dashboard/app/api/dev/agent/browser/route.ts
+++ b/dashboard/app/api/dev/agent/browser/route.ts
@@ -1,0 +1,34 @@
+import { runBrowserAgentTask } from '../../../../../src/server/agent/browserAgentService';
+
+export const runtime = 'nodejs';
+
+export type BrowserAgentRequestBody = {
+  task: string;
+  repoPath?: string;
+  files?: string[];
+  extraContext?: string;
+};
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const body = (await request.json()) as BrowserAgentRequestBody;
+    if (!body?.task || !body.task.trim()) {
+      return new Response(JSON.stringify({ error: 'task is required' }), { status: 400 });
+    }
+
+    const result = await runBrowserAgentTask({
+      task: body.task,
+      repoPath: body.repoPath || process.cwd(),
+      files: body.files,
+      extraContext: body.extraContext,
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Browser agent API error', error);
+    return new Response(JSON.stringify({ error: 'Failed to run agent' }), { status: 500 });
+  }
+}

--- a/dashboard/app/api/dev/agent/parallel/route.ts
+++ b/dashboard/app/api/dev/agent/parallel/route.ts
@@ -1,0 +1,30 @@
+import { runParallelAgentTask } from '../../../../../src/server/agent/parallelAgentService';
+
+export const runtime = 'nodejs';
+
+export type ParallelAgentRequestBody = {
+  task: string;
+  repoPath?: string;
+};
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const body = (await request.json()) as ParallelAgentRequestBody;
+    if (!body?.task || !body.task.trim()) {
+      return new Response(JSON.stringify({ error: 'task is required' }), { status: 400 });
+    }
+
+    const result = await runParallelAgentTask({
+      task: body.task,
+      repoPath: body.repoPath || process.cwd(),
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Parallel agent API error', error);
+    return new Response(JSON.stringify({ error: 'Failed to run parallel agent' }), { status: 500 });
+  }
+}

--- a/docs/dev/agents.md
+++ b/docs/dev/agents.md
@@ -1,0 +1,47 @@
+# Dev Agents
+
+This project includes a lightweight developer agent stack for local use. The stack is designed for development and debugging; routes and CLIs are dev-only and rely on your local dev server if available.
+
+## Browser Agent
+
+The Browser Agent wraps our existing Gemini helper with repo-aware, docs-aware, and cloud-aware context gathering.
+
+**Usage**
+
+```bash
+pnpm agent browse "Explain all FHIR endpoints in this repo and suggest a new MedicationRequest route."
+pnpm agent spec "Propose a spec + file list for integrating YouTube metrics into Marketing Studio."
+pnpm agent patch "Draft code changes to refactor Morning Briefing into a Gemini/Vertex specific service."
+```
+
+**What it does**
+- Reads relevant repository files (limited selection to avoid huge context) and shares snippets with the model.
+- Adds curated doc snippets based on task keywords (Next.js app router, Supabase, LangGraph, FHIR, YouTube metrics).
+- Summarizes Supabase and GCP config from environment variables and migration folders.
+- Falls back to a local summarizer when cloud APIs are not configured.
+
+The Browser Agent is also exposed as a dev-only API route at `/api/dev/agent/browser` (POST).
+
+## Parallel Agent
+
+The Parallel Agent orchestrates three Browser Agent subtasks (research, spec, code) concurrently.
+
+**Usage**
+
+```bash
+pnpm agent:parallel "Add a full FHIR MedicationRequest module wired to IPrescribe and our EMR patient model."
+pnpm agent:parallel "Extend Morning Briefing to include operations/compliance alerts with audit logging."
+```
+
+Each subtask returns its own summary, and artifacts are merged (later subtasks win on conflicting paths). The orchestrator is also reachable via `/api/dev/agent/parallel` (POST).
+
+## Super Browser capabilities
+
+- **Repo awareness**: Selects relevant files from `services`, `src/server`, `dashboard/app/api`, `components`, and `supabase/migrations`, extracts snippets, and attaches them to the prompt.
+- **Docs awareness**: Adds curated reminders for Next.js app router, Supabase migrations/RLS, LangGraph/LangChain orchestration, FHIR primitives, and YouTube metrics when the task mentions them.
+- **Cloud awareness**: Summarizes Supabase URLs/keys (masked), Cloud Run/GCP identifiers, Pub/Sub topics, and available Supabase migration folders so the model codes against the right resources.
+
+## Notes
+
+- The CLIs will try the local dev API first (`http://localhost:3000`); if unavailable they fall back to running the agent in-process.
+- Provide `API_KEY` (Gemini) or other provider keys if you want real model output; otherwise, a safe local summary is returned.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "clean:git": "git clean -fd",
     "preview": "vite preview",
     "electron": "tsx electron/main.ts",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "agent": "ts-node tools/agent-cli.ts",
+    "agent:parallel": "ts-node tools/agent-parallel-cli.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/src/server/agent/browserAgentService.ts
+++ b/src/server/agent/browserAgentService.ts
@@ -1,0 +1,90 @@
+import { getCloudContextSummary } from './context/cloudContext';
+import { getDocsContextForTask } from './context/docsContext';
+import {
+  buildRepoContextSnippet,
+  listRelevantFiles,
+  readFilesForContext,
+} from './context/repoContext';
+
+export type BrowserAgentInput = {
+  task: string;
+  repoPath?: string;
+  files?: string[];
+  extraContext?: string;
+};
+
+export type BrowserAgentArtifact = {
+  path: string;
+  content: string;
+};
+
+export type BrowserAgentResult = {
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+};
+
+function buildPrompt(task: string, context: string): string {
+  return `You are the Browser Agent for this repository. Complete the following task with concise reasoning and actionable output.\n\nTask:\n${task}\n\nContext:\n${context}`;
+}
+
+async function gatherRepoContext(repoPath?: string, files?: string[]): Promise<{ snippet: string; usedFiles: string[] }> {
+  if (!repoPath) return { snippet: '', usedFiles: [] };
+  const targetFiles = files?.length ? files : await listRelevantFiles(repoPath);
+  const repoFiles = await readFilesForContext(repoPath, targetFiles.slice(0, 15));
+  return { snippet: buildRepoContextSnippet(repoFiles), usedFiles: repoFiles.map((file) => file.path) };
+}
+
+async function attemptGeminiSummary(prompt: string): Promise<string> {
+  try {
+    const module = await import('../../../services/geminiService');
+    const service = module.geminiService;
+    const response = await service.summarizeText(prompt);
+    if (response) return response.trim();
+  } catch (error) {
+    console.info('Gemini summary unavailable, using fallback.', error);
+  }
+  return `Planned response for prompt:\n${prompt.slice(0, 1200)}`;
+}
+
+export async function runBrowserAgentTask(input: BrowserAgentInput): Promise<BrowserAgentResult> {
+  const logs: string[] = [];
+  try {
+    const { task, repoPath, files, extraContext } = input;
+    if (!task || !task.trim()) {
+      return { summary: 'No task provided.', logs };
+    }
+
+    const repoContext = await gatherRepoContext(repoPath, files);
+    if (repoContext.snippet) logs.push('Included repository context.');
+    const docsContext = await getDocsContextForTask(task);
+    if (docsContext) logs.push('Included docs context.');
+    const cloudContext = await getCloudContextSummary(repoPath);
+    if (cloudContext) logs.push('Included cloud context.');
+
+    const combinedContext = [repoContext.snippet, docsContext, cloudContext, extraContext]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const prompt = buildPrompt(task, combinedContext);
+    const summary = await attemptGeminiSummary(prompt);
+
+    const artifacts: BrowserAgentArtifact[] = [];
+    if (repoContext.usedFiles.length) {
+      artifacts.push({
+        path: 'agent/context-summary.txt',
+        content: combinedContext,
+      });
+    }
+
+    logs.push(`Processed ${repoContext.usedFiles.length} repo files.`);
+    return { summary, artifacts, logs };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logs.push(`Browser agent failed: ${message}`);
+    return {
+      summary: `Task failed safely: ${message}`,
+      logs,
+    };
+  }
+}

--- a/src/server/agent/context/cloudContext.ts
+++ b/src/server/agent/context/cloudContext.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+function mask(value?: string): string {
+  if (!value) return 'not set';
+  if (value.length <= 4) return '****';
+  return `${value.slice(0, 4)}…${value.slice(-2)}`;
+}
+
+async function readSupabaseMigrations(repoPath: string): Promise<string[]> {
+  const migrationsDir = path.join(repoPath, 'supabase', 'migrations');
+  try {
+    const entries = await fs.readdir(migrationsDir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+export async function getCloudContextSummary(repoPath?: string): Promise<string> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const gcpProjectId = process.env.GCP_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT;
+  const cloudRunService = process.env.CLOUD_RUN_SERVICE;
+  const pubsubTopic = process.env.PUBSUB_TOPIC || process.env.PUBSUB_NOTIFICATIONS_TOPIC;
+
+  const migrations = repoPath ? await readSupabaseMigrations(repoPath) : [];
+
+  const supabaseSummary = `Supabase config: URL=${mask(supabaseUrl)}, anonKey=${mask(
+    supabaseAnonKey
+  )}, serviceKey=${mask(supabaseServiceKey)}`;
+  const gcpSummary = `GCP config: project=${gcpProjectId || 'not set'}, cloud run=${
+    cloudRunService || 'n/a'
+  }, pubsub topic=${pubsubTopic || 'n/a'}`;
+  const migrationSummary = migrations.length
+    ? `Found migrations: ${migrations.join(', ')}`
+    : 'No migrations found or directory missing.';
+
+  return [supabaseSummary, gcpSummary, migrationSummary].join('\n');
+}

--- a/src/server/agent/context/docsContext.ts
+++ b/src/server/agent/context/docsContext.ts
@@ -1,0 +1,37 @@
+const docsCatalog: { keywords: string[]; snippet: string }[] = [
+  {
+    keywords: ['next', 'app router', 'route'],
+    snippet:
+      'Next.js App Router: API routes live under app/api/*/route.ts with Request/Response handlers. Use edge-safe APIs and export runtime = "nodejs" when accessing Node features.',
+  },
+  {
+    keywords: ['supabase', 'rls', 'schema'],
+    snippet:
+      'Supabase: use the project service role key for server-side calls. Migrations live in supabase/migrations with SQL defining tables, RLS policies, and seeds.',
+  },
+  {
+    keywords: ['langgraph', 'langchain', 'agent'],
+    snippet:
+      'LangGraph/LangChain: prefer small graphs orchestrating tools. Keep tool descriptions concise and deterministic; stream updates when running long tasks.',
+  },
+  {
+    keywords: ['fhir', 'medicationrequest', 'observation'],
+    snippet:
+      'FHIR: MedicationRequest resources include medication, dosageInstruction, requester, and intent. Observation resources capture vital signs or labs with subject, performer, and valueQuantity.',
+  },
+  {
+    keywords: ['youtube', 'metrics', 'marketing'],
+    snippet:
+      'YouTube metrics: gather viewCount, likeCount, impressionCount, and watchTime for reporting. Use incremental sync jobs to avoid quota spikes.',
+  },
+];
+
+export async function getDocsContextForTask(task: string): Promise<string> {
+  if (!task) return '';
+  const normalized = task.toLowerCase();
+  const matched = docsCatalog.filter((entry) =>
+    entry.keywords.some((keyword) => normalized.includes(keyword))
+  );
+  if (!matched.length) return '';
+  return `Relevant docs snippets:\n${matched.map((m) => `- ${m.snippet}`).join('\n')}`;
+}

--- a/src/server/agent/context/repoContext.ts
+++ b/src/server/agent/context/repoContext.ts
@@ -1,0 +1,83 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export type RepoFile = {
+  path: string;
+  content: string;
+};
+
+const DEFAULT_IGNORES = new Set([
+  'node_modules',
+  '.git',
+  '.next',
+  'dist',
+  'dist-electron',
+  'electron-dist',
+  '.turbo',
+  '.cache',
+]);
+
+const DEFAULT_PATTERNS = [
+  'dashboard/app/api/**/*.ts',
+  'src/server/**/*.ts',
+  'services/**/*.ts',
+  'supabase/migrations/**/*.sql',
+  'components/**/*.tsx',
+  'components/**/*.ts',
+];
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const withWildcards = escaped
+    .replace(/\\\*\\\*/g, '.*')
+    .replace(/\\\*/g, '[^/]*');
+  return new RegExp(`^${withWildcards}$`);
+}
+
+async function walkDir(baseDir: string, dir: string, files: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (DEFAULT_IGNORES.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.relative(baseDir, fullPath).replace(/\\/g, '/');
+    if (entry.isDirectory()) {
+      await walkDir(baseDir, fullPath, files);
+    } else {
+      files.push(relPath);
+    }
+  }
+}
+
+export async function listRelevantFiles(repoPath: string, pattern?: string | string[]): Promise<string[]> {
+  const patterns = Array.isArray(pattern) ? pattern : pattern ? [pattern] : DEFAULT_PATTERNS;
+  const regexes = patterns.map(globToRegex);
+  const files: string[] = [];
+  await walkDir(repoPath, repoPath, files);
+  return files.filter((file) => regexes.some((regex) => regex.test(file)));
+}
+
+export async function readFilesForContext(repoPath: string, paths: string[], maxBytes = 20_000): Promise<RepoFile[]> {
+  const results: RepoFile[] = [];
+  for (const relPath of paths) {
+    try {
+      const absolute = path.isAbsolute(relPath) ? relPath : path.join(repoPath, relPath);
+      const stat = await fs.stat(absolute);
+      if (stat.size > maxBytes) continue;
+      const content = await fs.readFile(absolute, 'utf8');
+      results.push({ path: relPath, content });
+    } catch (error) {
+      // Skip unreadable files
+      continue; // eslint-disable-line no-continue
+    }
+  }
+  return results;
+}
+
+export function buildRepoContextSnippet(files: RepoFile[], maxPerFile = 800): string {
+  if (!files.length) return '';
+  const parts = files.map((file) => {
+    const excerpt = file.content.length > maxPerFile ? `${file.content.slice(0, maxPerFile)}...` : file.content;
+    return `File: ${file.path}\n${excerpt}`;
+  });
+  return `Repository context (partial):\n${parts.join('\n\n')}`;
+}

--- a/src/server/agent/parallelAgentService.ts
+++ b/src/server/agent/parallelAgentService.ts
@@ -1,0 +1,83 @@
+import { BrowserAgentArtifact, runBrowserAgentTask } from './browserAgentService';
+
+export type ParallelAgentInput = {
+  task: string;
+  repoPath?: string;
+};
+
+export type ParallelAgentSubtaskResult = {
+  name: string;
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+};
+
+export type ParallelAgentResult = {
+  summary: string;
+  subtasks: ParallelAgentSubtaskResult[];
+  artifacts: BrowserAgentArtifact[];
+  logs: string[];
+};
+
+async function runSubtask(name: string, task: string, repoPath?: string) {
+  try {
+    return await runBrowserAgentTask({ task, repoPath });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return { summary: `Subtask failed: ${message}`, logs: [`${name} failed: ${message}`] };
+  }
+}
+
+export async function runParallelAgentTask(input: ParallelAgentInput): Promise<ParallelAgentResult> {
+  const logs: string[] = [];
+  const { task, repoPath } = input;
+  if (!task || !task.trim()) {
+    return { summary: 'No task provided.', subtasks: [], artifacts: [], logs };
+  }
+
+  const subtasks = [
+    {
+      name: 'research',
+      prompt: `Research external docs and our codebase context needed to accomplish: ${task}. Focus on APIs, integrations, constraints, and EMR modules. Return a structured summary and suggestions.`,
+    },
+    {
+      name: 'spec',
+      prompt: `Generate a concise technical spec and file-level plan for: ${task}. Use our architecture patterns and keep the output concise.`,
+    },
+    {
+      name: 'code',
+      prompt: `Draft code artifacts or patches to implement: ${task}. Follow our project conventions and TypeScript patterns. Include file paths and contents.`,
+    },
+  ];
+
+  const results = await Promise.all(
+    subtasks.map(async (subtask) => {
+      const result = await runSubtask(subtask.name, subtask.prompt, repoPath);
+      return {
+        name: subtask.name,
+        summary: result.summary,
+        artifacts: result.artifacts,
+        logs: result.logs,
+      };
+    })
+  );
+
+  const artifactMap = new Map<string, BrowserAgentArtifact>();
+  results.forEach((result) => {
+    result.artifacts?.forEach((artifact) => {
+      artifactMap.set(artifact.path, artifact);
+    });
+  });
+
+  const flattenedArtifacts = Array.from(artifactMap.values());
+  const failed = results.filter((r) => r.summary.toLowerCase().startsWith('subtask failed'));
+  const summary = `Parallel agent completed. ${results.length - failed.length}/${results.length} subtasks succeeded. Produced ${flattenedArtifacts.length} artifacts.`;
+  logs.push(`Completed subtasks with ${failed.length} failures.`);
+
+  return {
+    summary,
+    subtasks: results,
+    artifacts: flattenedArtifacts,
+    logs,
+  };
+}

--- a/tools/agent-cli.ts
+++ b/tools/agent-cli.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env ts-node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { runBrowserAgentTask } from '../src/server/agent/browserAgentService';
+
+const API_URL = 'http://localhost:3000/api/dev/agent/browser';
+
+async function writeArtifacts(repoPath: string, artifacts?: { path: string; content: string }[]) {
+  if (!artifacts?.length) return;
+  for (const artifact of artifacts) {
+    const targetPath = path.isAbsolute(artifact.path)
+      ? artifact.path
+      : path.join(repoPath, artifact.path);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, artifact.content, 'utf8');
+    console.log(`🔧 wrote ${targetPath}`);
+  }
+}
+
+async function callApi(task: string, repoPath: string) {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ task, repoPath }),
+  });
+  if (!response.ok) {
+    throw new Error(`API error ${response.status}`);
+  }
+  return (await response.json()) as any;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const subcommand = args.shift();
+  const task = args.join(' ').trim();
+
+  if (!task) {
+    console.error('Usage: pnpm agent <subcommand?> "task description"');
+    process.exit(1);
+  }
+
+  const repoPath = process.cwd();
+  console.log(`Running agent${subcommand ? ` (${subcommand})` : ''} for task: ${task}`);
+
+  try {
+    const result = await callApi(task, repoPath);
+    console.log('=== Agent Summary ===');
+    console.log(result.summary);
+    console.log('=== Generated Artifacts ===');
+    await writeArtifacts(repoPath, result.artifacts);
+    if (result.logs?.length) {
+      console.log('=== Logs ===');
+      result.logs.forEach((log: string) => console.log(log));
+    }
+  } catch (error) {
+    console.warn('API unavailable, running locally.', error);
+    const fallback = await runBrowserAgentTask({ task, repoPath });
+    console.log('=== Agent Summary ===');
+    console.log(fallback.summary);
+    console.log('=== Generated Artifacts ===');
+    await writeArtifacts(repoPath, fallback.artifacts);
+    if (fallback.logs?.length) {
+      console.log('=== Logs ===');
+      fallback.logs.forEach((log) => console.log(log));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Agent CLI failed', error);
+  process.exit(1);
+});

--- a/tools/agent-parallel-cli.ts
+++ b/tools/agent-parallel-cli.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env ts-node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { runParallelAgentTask } from '../src/server/agent/parallelAgentService';
+
+const API_URL = 'http://localhost:3000/api/dev/agent/parallel';
+
+async function writeArtifacts(repoPath: string, artifacts?: { path: string; content: string }[]) {
+  if (!artifacts?.length) return;
+  for (const artifact of artifacts) {
+    const targetPath = path.isAbsolute(artifact.path)
+      ? artifact.path
+      : path.join(repoPath, artifact.path);
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.writeFile(targetPath, artifact.content, 'utf8');
+    console.log(`🔧 wrote ${targetPath}`);
+  }
+}
+
+async function callApi(task: string, repoPath: string) {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ task, repoPath }),
+  });
+  if (!response.ok) {
+    throw new Error(`API error ${response.status}`);
+  }
+  return (await response.json()) as any;
+}
+
+async function main() {
+  const task = process.argv.slice(2).join(' ').trim();
+  if (!task) {
+    console.error('Usage: pnpm agent:parallel "<task description>"');
+    process.exit(1);
+  }
+
+  const repoPath = process.cwd();
+  console.log(`Running parallel agent for task: ${task}`);
+
+  try {
+    const result = await callApi(task, repoPath);
+    console.log('=== Parallel Agent Summary ===');
+    console.log(result.summary);
+
+    console.log('=== Subtasks ===');
+    result.subtasks?.forEach((subtask: any) => {
+      console.log(`- ${subtask.name}: ${subtask.summary}`);
+    });
+
+    console.log('=== Generated Artifacts ===');
+    await writeArtifacts(repoPath, result.artifacts);
+
+    if (result.logs?.length) {
+      console.log('=== Logs ===');
+      result.logs.forEach((log: string) => console.log(log));
+    }
+  } catch (error) {
+    console.warn('Parallel API unavailable, running locally.', error);
+    const fallback = await runParallelAgentTask({ task, repoPath });
+    console.log('=== Parallel Agent Summary ===');
+    console.log(fallback.summary);
+
+    console.log('=== Subtasks ===');
+    fallback.subtasks.forEach((subtask) => {
+      console.log(`- ${subtask.name}: ${subtask.summary}`);
+    });
+
+    console.log('=== Generated Artifacts ===');
+    await writeArtifacts(repoPath, fallback.artifacts);
+
+    if (fallback.logs?.length) {
+      console.log('=== Logs ===');
+      fallback.logs.forEach((log) => console.log(log));
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Parallel agent CLI failed', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add browser agent service with repo, docs, and cloud context helpers
- expose dev-only browser and parallel agent APIs plus CLI wrappers
- document usage for the agent tools and super browser capabilities

## Testing
- npm run build -- --version


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfd0585b0832487b7f957be3ffd1e)