### PR TITLE
Add MCP-aware agents and tooling

### DIFF
--- a/dashboard/app/api/dev/agent/browser/route.ts
+++ b/dashboard/app/api/dev/agent/browser/route.ts
@@ -1,0 +1,27 @@
+import { runBrowserAgentTask } from '@/src/server/agent/browserAgentService';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const body = await request.json();
+    const result = await runBrowserAgentTask({
+      task: body.task,
+      repoPath: body.repoPath,
+      files: body.files,
+      extraContext: body.extraContext,
+      useMCP: body.useMCP ?? false,
+      allowedMCPTools: body.allowedMCPTools,
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+}

--- a/dashboard/app/api/dev/agent/parallel/route.ts
+++ b/dashboard/app/api/dev/agent/parallel/route.ts
@@ -1,0 +1,25 @@
+import { runParallelAgentTask } from '@/src/server/agent/parallelAgentService';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const body = await request.json();
+    const result = await runParallelAgentTask({
+      task: body.task,
+      repoPath: body.repoPath,
+      useMCP: body.useMCP ?? false,
+      allowedMCPTools: body.allowedMCPTools,
+    });
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+}

--- a/dashboard/app/api/dev/mcp/tools/route.ts
+++ b/dashboard/app/api/dev/mcp/tools/route.ts
@@ -1,0 +1,28 @@
+import { categorizeMCPTool, listMCPTools, MCPToolCategory } from '@/src/server/mcp/mcpClient';
+
+export const runtime = 'nodejs';
+
+export async function GET(): Promise<Response> {
+  try {
+    const tools = await listMCPTools();
+    const categorized = tools.reduce<Record<MCPToolCategory, typeof tools>>(
+      (acc, tool) => {
+        const category = categorizeMCPTool(tool);
+        acc[category] = acc[category] || [];
+        acc[category].push(tool);
+        return acc;
+      },
+      { clinical: [], marketing: [], education: [], ops: [], other: [] },
+    );
+
+    return new Response(JSON.stringify({ tools, categorized }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+}

--- a/docs/dev/mcp-agents.md
+++ b/docs/dev/mcp-agents.md
@@ -1,0 +1,39 @@
+# MCP-aware Agent Stack
+
+This document explains how the browser and parallel agents can optionally use MCP tools for richer workflows.
+
+## Mental Model
+- **Browser Agent** handles planning and single-task execution.
+- **Parallel Agent** breaks work into research/spec/code subtasks.
+- **MCP tools** provide clinical, marketing, education, and ops capabilities that the agents can invoke when enabled.
+
+## Enabling MCP for Agents
+Both agents accept the `useMCP` flag and optional `allowedMCPTools` list to limit scope. If `useMCP` is false, existing behavior is unchanged.
+
+### Browser Agent
+- Entry point: `/api/dev/agent/browser`
+- Flags: `useMCP`, `allowedMCPTools`
+- Output includes any MCP calls performed.
+
+### Parallel Agent
+- Entry point: `/api/dev/agent/parallel`
+- Each subtask forwards MCP options and aggregates tool calls.
+
+## CLI Usage Examples
+```bash
+# Let the browser agent use MCP tools
+pnpm agent browse --mcp --tools=clinical.rag_search "Summarize obesity treatment workflows and propose AI triage upgrades."
+
+# Run the parallel agent with specific tools
+pnpm agent:parallel --mcp --tools=clinical.rag_search,marketing.outline "Design a DPC onboarding micro-course for new patients."
+```
+
+Set `DEV_API_BASE_URL` if your dev API is not running on `http://localhost:3000`.
+
+## Inspecting MCP Tools
+A dev endpoint lists available tools with basic categorization:
+- `GET /api/dev/mcp/tools`
+
+## Safety & Scope
+- Keep `useMCP` off by default when testing unrelated features.
+- Pass `--tools` to constrain what the agents may call (e.g., only clinical tools during EMR tasks).

--- a/src/server/agent/browserAgentService.ts
+++ b/src/server/agent/browserAgentService.ts
@@ -1,0 +1,92 @@
+import { categorizeMCPTool, invokeMCPTool, listMCPTools, MCPInvocationResult, MCPTool } from '../mcp/mcpClient';
+
+export type BrowserAgentArtifact = {
+  type: 'text' | 'link' | 'file';
+  content: string;
+  label?: string;
+};
+
+export type BrowserAgentInput = {
+  task: string;
+  repoPath?: string;
+  files?: string[];
+  extraContext?: string;
+  useMCP?: boolean;
+  allowedMCPTools?: string[];
+};
+
+export type BrowserAgentResult = {
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+  mcpCalls?: MCPInvocationResult[];
+};
+
+function describeTools(tools: MCPTool[]): string {
+  if (!tools.length) return 'No MCP tools available.';
+
+  return tools
+    .map(tool => {
+      const description = tool.description ? ` - ${tool.description}` : '';
+      return `${tool.name}${description}`;
+    })
+    .join('\n');
+}
+
+async function selectTools(useMCP: boolean | undefined, allowedMCPTools?: string[]): Promise<MCPTool[]> {
+  if (!useMCP) return [];
+
+  const availableTools = await listMCPTools();
+  if (!allowedMCPTools?.length) return availableTools;
+
+  const allowedSet = new Set(allowedMCPTools.map(name => name.toLowerCase()));
+  return availableTools.filter(tool => allowedSet.has(tool.name.toLowerCase()));
+}
+
+export async function runBrowserAgentTask(input: BrowserAgentInput): Promise<BrowserAgentResult> {
+  const logs: string[] = [`Starting browser agent task: ${input.task}`];
+  const mcpCalls: MCPInvocationResult[] = [];
+
+  const selectedTools = await selectTools(input.useMCP, input.allowedMCPTools);
+  if (input.useMCP) {
+    logs.push(`MCP enabled. ${selectedTools.length} tools available after filtering.`);
+  }
+
+  const contextSummary = `Task: ${input.task}\nRepo: ${input.repoPath || 'n/a'}\nFiles: ${(input.files || []).join(', ') || 'none'}\nExtra: ${input.extraContext || 'n/a'}`;
+  const mcpToolSummary = input.useMCP ? describeTools(selectedTools) : 'MCP disabled.';
+
+  logs.push('Context prepared for agent.');
+  logs.push('Available MCP tools:\n' + mcpToolSummary);
+
+  if (input.useMCP && selectedTools.length) {
+    const maxCalls = Math.min(3, selectedTools.length);
+    for (let i = 0; i < maxCalls; i++) {
+      const tool = selectedTools[i];
+      const category = categorizeMCPTool(tool);
+      logs.push(`Invoking MCP tool ${tool.name} (category: ${category}).`);
+      const result = await invokeMCPTool({ toolName: tool.name });
+      mcpCalls.push(result);
+      logs.push(`MCP tool ${tool.name} completed.`);
+    }
+  }
+
+  const summaryParts = [
+    'Browser agent run completed.',
+    input.useMCP && selectedTools.length
+      ? `Used ${mcpCalls.length} MCP tool(s) (${selectedTools.length} available).`
+      : 'MCP usage was disabled or no tools were available.',
+  ];
+
+  return {
+    summary: summaryParts.join(' '),
+    artifacts: [
+      {
+        type: 'text',
+        content: contextSummary,
+        label: 'Context',
+      },
+    ],
+    logs,
+    mcpCalls,
+  };
+}

--- a/src/server/agent/parallelAgentService.ts
+++ b/src/server/agent/parallelAgentService.ts
@@ -1,0 +1,126 @@
+import { BrowserAgentArtifact, BrowserAgentResult, runBrowserAgentTask } from './browserAgentService';
+import { categorizeMCPTool, listMCPTools, MCPInvocationResult, MCPTool, MCPToolCategory } from '../mcp/mcpClient';
+
+export type ParallelAgentInput = {
+  task: string;
+  repoPath?: string;
+  useMCP?: boolean;
+  allowedMCPTools?: string[];
+};
+
+export type ParallelAgentSubtaskResult = {
+  name: string;
+  summary: string;
+  artifacts?: BrowserAgentArtifact[];
+  logs?: string[];
+  mcpCalls?: MCPInvocationResult[];
+};
+
+export type ParallelAgentResult = {
+  summary: string;
+  subtasks: ParallelAgentSubtaskResult[];
+  artifacts: BrowserAgentArtifact[];
+  logs: string[];
+  mcpCalls: MCPInvocationResult[];
+};
+
+function formatToolName(tool: MCPTool): string {
+  return tool.namespace ? `${tool.namespace}.${tool.name}` : tool.name;
+}
+
+function filterToolsByCategory(tools: MCPTool[], categories: MCPToolCategory[], allowed?: string[]): string[] {
+  const allowedSet = allowed && allowed.length ? new Set(allowed.map(name => name.toLowerCase())) : undefined;
+  return tools
+    .filter(tool => categories.includes(categorizeMCPTool(tool)))
+    .map(formatToolName)
+    .filter(name => !allowedSet || allowedSet.has(name.toLowerCase()));
+}
+
+async function prepareMCPTooling(useMCP?: boolean, allowedMCPTools?: string[]) {
+  if (!useMCP) return { available: [] as MCPTool[], research: [] as string[], spec: [] as string[], code: [] as string[] };
+
+  const available = await listMCPTools();
+  const research = filterToolsByCategory(available, ['clinical', 'education', 'marketing'], allowedMCPTools);
+  const spec = filterToolsByCategory(available, ['clinical', 'education', 'ops', 'marketing'], allowedMCPTools);
+  const code = filterToolsByCategory(available, ['ops'], allowedMCPTools);
+
+  return { available, research, spec, code };
+}
+
+function buildSummary(mcpCalls: MCPInvocationResult[], subtasks: ParallelAgentSubtaskResult[]): string {
+  const totalCalls = mcpCalls.length;
+  const categories = ['clinical', 'marketing', 'education', 'ops', 'other'] as MCPToolCategory[];
+  const categoryCounts = categories.reduce<Record<string, number>>((acc, category) => {
+    acc[category] = 0;
+    return acc;
+  }, {});
+
+  for (const call of mcpCalls) {
+    const category = categories.find(cat => call.toolName.toLowerCase().startsWith(`${cat}.`)) || 'other';
+    categoryCounts[category] += 1;
+  }
+
+  const categorySummary = categories
+    .filter(category => categoryCounts[category] > 0)
+    .map(category => `${categoryCounts[category]} ${category}`)
+    .join(', ');
+
+  const subtaskSummary = subtasks.map(sub => `${sub.name}: ${sub.summary}`).join(' ');
+  const mcpSummary = totalCalls ? `MCP usage: ${totalCalls} call(s)${categorySummary ? ` (${categorySummary})` : ''}.` : 'No MCP tools were used.';
+
+  return `${subtaskSummary} ${mcpSummary}`.trim();
+}
+
+export async function runParallelAgentTask(input: ParallelAgentInput): Promise<ParallelAgentResult> {
+  const logs: string[] = [`Starting parallel agent for task: ${input.task}`];
+  const mcpCalls: MCPInvocationResult[] = [];
+
+  const { research, spec, code } = await prepareMCPTooling(input.useMCP, input.allowedMCPTools);
+
+  const researchResult: BrowserAgentResult = await runBrowserAgentTask({
+    task: `Research: ${input.task}`,
+    repoPath: input.repoPath,
+    useMCP: input.useMCP,
+    allowedMCPTools: research.length ? research : input.allowedMCPTools,
+  });
+  mcpCalls.push(...(researchResult.mcpCalls || []));
+
+  const specResult: BrowserAgentResult = await runBrowserAgentTask({
+    task: `Specification: ${input.task}`,
+    repoPath: input.repoPath,
+    useMCP: input.useMCP,
+    allowedMCPTools: spec.length ? spec : input.allowedMCPTools,
+  });
+  mcpCalls.push(...(specResult.mcpCalls || []));
+
+  const codeResult: BrowserAgentResult = await runBrowserAgentTask({
+    task: `Implementation: ${input.task}`,
+    repoPath: input.repoPath,
+    useMCP: input.useMCP,
+    allowedMCPTools: code.length ? code : input.allowedMCPTools,
+  });
+  mcpCalls.push(...(codeResult.mcpCalls || []));
+
+  const subtasks: ParallelAgentSubtaskResult[] = [
+    { name: 'research', summary: researchResult.summary, artifacts: researchResult.artifacts, logs: researchResult.logs, mcpCalls: researchResult.mcpCalls },
+    { name: 'spec', summary: specResult.summary, artifacts: specResult.artifacts, logs: specResult.logs, mcpCalls: specResult.mcpCalls },
+    { name: 'code', summary: codeResult.summary, artifacts: codeResult.artifacts, logs: codeResult.logs, mcpCalls: codeResult.mcpCalls },
+  ];
+
+  const artifacts: BrowserAgentArtifact[] = [
+    ...(researchResult.artifacts || []),
+    ...(specResult.artifacts || []),
+    ...(codeResult.artifacts || []),
+  ];
+
+  const summary = buildSummary(mcpCalls, subtasks);
+  logs.push('Parallel agent run completed.');
+
+  return {
+    summary,
+    subtasks,
+    artifacts,
+    logs,
+    mcpCalls,
+  };
+}

--- a/src/server/mcp/mcpClient.ts
+++ b/src/server/mcp/mcpClient.ts
@@ -1,0 +1,133 @@
+const DEFAULT_MCP_BASE_URL = process.env.MCP_SERVER_URL || process.env.NEXT_PUBLIC_MCP_SERVER_URL || 'http://localhost:4000';
+const MCP_API_KEY = process.env.MCP_API_KEY;
+
+export type MCPTool = {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  outputSchema?: unknown;
+  namespace?: string;
+};
+
+export type MCPInvocationInput = {
+  toolName: string;
+  args?: Record<string, unknown>;
+};
+
+export type MCPInvocationResult = {
+  toolName: string;
+  raw: unknown;
+  summary?: string;
+};
+
+export type MCPToolCategory = 'clinical' | 'marketing' | 'education' | 'ops' | 'other';
+
+function getMCPBaseUrl(): string {
+  const trimmed = DEFAULT_MCP_BASE_URL?.replace(/\/$/, '');
+  return trimmed || 'http://localhost:4000';
+}
+
+function getHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (MCP_API_KEY) {
+    headers.Authorization = `Bearer ${MCP_API_KEY}`;
+  }
+
+  return headers;
+}
+
+function normalizeToolName(tool: MCPTool): string {
+  if (tool.namespace && !tool.name.startsWith(`${tool.namespace}.`)) {
+    return `${tool.namespace}.${tool.name}`;
+  }
+  return tool.name;
+}
+
+export async function listMCPTools(): Promise<MCPTool[]> {
+  const baseUrl = getMCPBaseUrl();
+  try {
+    const response = await fetch(`${baseUrl}/tools`, {
+      method: 'GET',
+      headers: getHeaders(),
+    });
+
+    if (!response.ok) {
+      console.error(`[MCP client] Failed to list tools: ${response.status} ${response.statusText}`);
+      return [];
+    }
+
+    const payload = await response.json().catch(() => undefined);
+    const tools = (payload?.tools || payload || []) as MCPTool[];
+    return tools.map(tool => ({
+      ...tool,
+      name: normalizeToolName(tool),
+    }));
+  } catch (error) {
+    console.error('[MCP client] Error listing tools', error);
+    return [];
+  }
+}
+
+export async function invokeMCPTool(input: MCPInvocationInput): Promise<MCPInvocationResult> {
+  const baseUrl = getMCPBaseUrl();
+  try {
+    const response = await fetch(`${baseUrl}/invoke`, {
+      method: 'POST',
+      headers: getHeaders(),
+      body: JSON.stringify({
+        tool: input.toolName,
+        args: input.args || {},
+      }),
+    });
+
+    const raw = await response.json().catch(() => undefined);
+
+    if (!response.ok) {
+      console.error(`[MCP client] Invocation failed for ${input.toolName}: ${response.status} ${response.statusText}`);
+      return {
+        toolName: input.toolName,
+        raw: raw || { error: response.statusText },
+        summary: `Invocation failed for ${input.toolName}`,
+      };
+    }
+
+    const summary = typeof raw === 'object' && raw && 'summary' in (raw as Record<string, unknown>)
+      ? String((raw as Record<string, unknown>).summary)
+      : undefined;
+
+    return {
+      toolName: input.toolName,
+      raw,
+      summary,
+    };
+  } catch (error) {
+    console.error(`[MCP client] Error invoking ${input.toolName}`, error);
+    return {
+      toolName: input.toolName,
+      raw: { error: (error as Error).message },
+      summary: `Invocation failed for ${input.toolName}: ${(error as Error).message}`,
+    };
+  }
+}
+
+export function categorizeMCPTool(tool: MCPTool): MCPToolCategory {
+  const identifier = normalizeToolName(tool).toLowerCase();
+  const description = tool.description?.toLowerCase() || '';
+
+  if (identifier.startsWith('clinical.') || description.includes('clinical') || description.includes('patient')) {
+    return 'clinical';
+  }
+  if (identifier.startsWith('marketing.') || description.includes('marketing') || description.includes('seo')) {
+    return 'marketing';
+  }
+  if (identifier.startsWith('education.') || description.includes('course') || description.includes('learning')) {
+    return 'education';
+  }
+  if (identifier.startsWith('ops.') || identifier.startsWith('operations.') || description.includes('ops') || description.includes('operations')) {
+    return 'ops';
+  }
+  return 'other';
+}

--- a/tools/agent-cli.ts
+++ b/tools/agent-cli.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env ts-node
+
+const API_BASE = process.env.DEV_API_BASE_URL || 'http://localhost:3000';
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  const useMCP = args.includes('--mcp') || args.includes('--use-mcp');
+  const toolsArg = args.find(arg => arg.startsWith('--tools='));
+  const allowedMCPTools = toolsArg ? toolsArg.replace('--tools=', '').split(',').filter(Boolean) : undefined;
+  const task = args.filter(arg => !arg.startsWith('--')).join(' ');
+
+  return { useMCP, allowedMCPTools, task };
+}
+
+async function run() {
+  const { useMCP, allowedMCPTools, task } = parseArgs(process.argv);
+
+  if (!task) {
+    console.error('Usage: pnpm agent browse [--mcp] [--tools=tool1,tool2] "task description"');
+    process.exit(1);
+  }
+
+  const response = await fetch(`${API_BASE}/api/dev/agent/browser`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      task,
+      repoPath: process.cwd(),
+      useMCP,
+      allowedMCPTools,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Agent request failed:', errorText);
+    process.exit(1);
+  }
+
+  const result = await response.json();
+  console.log('Browser Agent Result:', JSON.stringify(result, null, 2));
+}
+
+run();

--- a/tools/agent-parallel-cli.ts
+++ b/tools/agent-parallel-cli.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env ts-node
+
+const API_BASE = process.env.DEV_API_BASE_URL || 'http://localhost:3000';
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2);
+  const useMCP = args.includes('--mcp') || args.includes('--use-mcp');
+  const toolsArg = args.find(arg => arg.startsWith('--tools='));
+  const allowedMCPTools = toolsArg ? toolsArg.replace('--tools=', '').split(',').filter(Boolean) : undefined;
+  const task = args.filter(arg => !arg.startsWith('--')).join(' ');
+
+  return { useMCP, allowedMCPTools, task };
+}
+
+async function run() {
+  const { useMCP, allowedMCPTools, task } = parseArgs(process.argv);
+
+  if (!task) {
+    console.error('Usage: pnpm agent:parallel [--mcp] [--tools=tool1,tool2] "task description"');
+    process.exit(1);
+  }
+
+  const response = await fetch(`${API_BASE}/api/dev/agent/parallel`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      task,
+      repoPath: process.cwd(),
+      useMCP,
+      allowedMCPTools,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Parallel agent request failed:', errorText);
+    process.exit(1);
+  }
+
+  const result = await response.json();
+  console.log('Parallel Agent Result:', JSON.stringify(result, null, 2));
+}
+
+run();


### PR DESCRIPTION
## Summary
- add MCP client wrapper plus MCP-enabled browser and parallel agent services
- expose dev API routes, CLI helpers, and MCP tool inspector endpoint
- document MCP-aware agent usage and CLI flags for local testing

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cfdd68f288324b6edde8166f74c7e)