### PR TITLE
Add voice command mode scaffolding

### DIFF
--- a/dashboard/app/api/voice/audio/[id]/route.ts
+++ b/dashboard/app/api/voice/audio/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getAudioBuffer } from '../../../../../../src/server/voice/audioStore';
+
+export const runtime = 'nodejs';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const audio = getAudioBuffer(params.id);
+  if (!audio) {
+    return NextResponse.json({ error: 'Audio not found' }, { status: 404 });
+  }
+
+  return new NextResponse(audio.buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': audio.mimeType,
+      'Content-Length': audio.buffer.byteLength.toString(),
+      'Cache-Control': 'public, max-age=60',
+    },
+  });
+}

--- a/dashboard/app/api/voice/command/route.ts
+++ b/dashboard/app/api/voice/command/route.ts
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+import { NextResponse } from 'next/server';
+import { handleVoiceCommand } from '../../../../../src/server/voice/voiceOrchestrator';
+import { transcribeAudio } from '../../../../../src/server/voice/sttClient';
+import { VoiceCommand } from '../../../../../src/server/voice/voiceTypes';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const audio = formData.get('audio');
+
+  if (!(audio instanceof File)) {
+    return NextResponse.json({ error: 'Audio file missing' }, { status: 400 });
+  }
+
+  const buffer = Buffer.from(await audio.arrayBuffer());
+  const stt = await transcribeAudio(buffer, { language: formData.get('language')?.toString() });
+  const mode = (formData.get('mode')?.toString() as 'plan' | 'run' | undefined) ?? 'plan';
+  const simulate = formData.get('simulate')?.toString() === 'true';
+
+  const voiceCommand: VoiceCommand = {
+    id: crypto.randomUUID(),
+    userId: formData.get('userId')?.toString() || 'demo-user',
+    brandId: formData.get('brandId')?.toString() || undefined,
+    practiceId: formData.get('practiceId')?.toString() || undefined,
+    transcript: stt.text,
+    createdAt: new Date().toISOString(),
+    context: {
+      lastMissionId: formData.get('lastMissionId')?.toString() || undefined,
+    },
+  };
+
+  const response = await handleVoiceCommand(voiceCommand, { mode, simulate });
+
+  return NextResponse.json({
+    transcript: stt.text,
+    transcriptSummary: response.transcriptSummary,
+    missionId: response.missionId,
+    ttsUrl: response.ttsUrl,
+    followupHints: response.followupHints,
+  });
+}

--- a/dashboard/app/dev/orchestrator/page.tsx
+++ b/dashboard/app/dev/orchestrator/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { executeMissionPlan, planMission } from '../../../../src/server/orchestrator';
+import {
+  MissionPlan,
+  MissionRequest,
+  MissionResult,
+  MissionType,
+} from '../../../../src/server/orchestrator/orchestratorTypes';
+import { listMissionTemplates } from '../../../../src/server/orchestrator/missionRegistry';
+import { VoiceSessionState } from '../../../../src/server/voice/voiceTypes';
+
+const defaultRequest: MissionRequest = {
+  id: 'mission-preview',
+  userId: 'user-dev',
+  type: 'marketing.campaign',
+  goal: 'Preview orchestrator mission planning',
+};
+
+export default function OrchestratorPage() {
+  const [missionRequest, setMissionRequest] = useState<MissionRequest>(defaultRequest);
+  const [plan, setPlan] = useState<MissionPlan | null>(null);
+  const [result, setResult] = useState<MissionResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [voiceState, setVoiceState] = useState<VoiceSessionState>('idle');
+  const [transcript, setTranscript] = useState('');
+  const [voiceSummary, setVoiceSummary] = useState('');
+  const [voiceMode, setVoiceMode] = useState<'plan' | 'run'>('plan');
+  const [ttsUrl, setTtsUrl] = useState<string | undefined>();
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const recordedChunksRef = useRef<Blob[]>([]);
+
+  const templates = useMemo(() => listMissionTemplates(), []);
+
+  useEffect(() => {
+    return () => {
+      mediaRecorderRef.current?.stream.getTracks().forEach((track) => track.stop());
+    };
+  }, []);
+
+  const handlePlan = async () => {
+    const generatedPlan = await planMission({ ...missionRequest, id: crypto.randomUUID() });
+    setPlan(generatedPlan);
+  };
+
+  const handleRun = async () => {
+    setIsRunning(true);
+    const generatedPlan =
+      plan || (await planMission({ ...missionRequest, id: crypto.randomUUID() }));
+    setPlan(generatedPlan);
+    const missionResult = await executeMissionPlan(generatedPlan);
+    setResult(missionResult);
+    setIsRunning(false);
+  };
+
+  const sendVoiceCommand = async (audioBlob: Blob) => {
+    setVoiceState('processing');
+    setVoiceError(null);
+    const formData = new FormData();
+    formData.append('audio', audioBlob, 'voice-command.webm');
+    formData.append('mode', voiceMode);
+    formData.append('simulate', 'false');
+
+    const response = await fetch('/api/voice/command', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      setVoiceError('Unable to process voice command.');
+      setVoiceState('idle');
+      return;
+    }
+
+    const payload = await response.json();
+    setTranscript(payload.transcript);
+    setVoiceSummary(payload.transcriptSummary);
+    setTtsUrl(payload.ttsUrl);
+    if (payload.missionId) {
+      setMissionRequest((prev) => ({ ...prev, id: payload.missionId }));
+    }
+    setVoiceState('responding');
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+  };
+
+  const startRecording = async () => {
+    setVoiceError(null);
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    recordedChunksRef.current = [];
+    const recorder = new MediaRecorder(stream);
+    mediaRecorderRef.current = recorder;
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        recordedChunksRef.current.push(event.data);
+      }
+    };
+
+    recorder.onstop = async () => {
+      const blob = new Blob(recordedChunksRef.current, { type: 'audio/webm' });
+      await sendVoiceCommand(blob);
+    };
+
+    recorder.start();
+    setVoiceState('listening');
+  };
+
+  const handleVoiceToggle = async () => {
+    if (voiceState === 'idle') {
+      await startRecording();
+      return;
+    }
+
+    if (voiceState === 'listening') {
+      setVoiceState('processing');
+      stopRecording();
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Orchestrator Control Center</h1>
+      <section className="space-y-2 p-4 border rounded">
+        <h2 className="font-semibold">Voice Command</h2>
+        <div className="flex items-center gap-2">
+          <button
+            className={`px-4 py-2 rounded text-white ${
+              voiceState === 'listening' ? 'bg-red-600' : 'bg-indigo-600'
+            }`}
+            onClick={handleVoiceToggle}
+          >
+            {voiceState === 'listening' ? 'Stop Listening' : 'Start Voice'}
+          </button>
+          <select
+            className="border rounded p-2"
+            value={voiceMode}
+            onChange={(e) => setVoiceMode(e.target.value as 'plan' | 'run')}
+          >
+            <option value="plan">Plan Only</option>
+            <option value="run">Plan + Run</option>
+          </select>
+          <div className="text-sm text-gray-600">Status: {voiceState}</div>
+        </div>
+        {voiceError ? <div className="text-sm text-red-600">{voiceError}</div> : null}
+        {transcript ? (
+          <div className="text-sm">
+            <div className="font-semibold">Transcript</div>
+            <div className="text-gray-700">{transcript}</div>
+          </div>
+        ) : null}
+        {voiceSummary ? (
+          <div className="text-sm">
+            <div className="font-semibold">Summary</div>
+            <div className="text-gray-700">{voiceSummary}</div>
+          </div>
+        ) : null}
+        {ttsUrl ? (
+          <audio controls className="w-full" src={ttsUrl} />
+        ) : null}
+      </section>
+      <section className="space-y-2 p-4 border rounded">
+        <h2 className="font-semibold">Mission Request</h2>
+        <label className="block text-sm text-gray-600">Mission Type</label>
+        <select
+          className="border rounded p-2 w-full"
+          value={missionRequest.type}
+          onChange={(e) =>
+            setMissionRequest((prev) => ({ ...prev, type: e.target.value as MissionType }))
+          }
+        >
+          {templates.map((template) => (
+            <option key={template.type} value={template.type}>
+              {template.name}
+            </option>
+          ))}
+        </select>
+        <label className="block text-sm text-gray-600">Goal</label>
+        <textarea
+          className="border rounded p-2 w-full"
+          value={missionRequest.goal}
+          onChange={(e) => setMissionRequest((prev) => ({ ...prev, goal: e.target.value }))}
+        />
+        <div className="flex gap-2">
+          <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={handlePlan}>
+            Build Plan
+          </button>
+          <button
+            className="bg-green-600 text-white px-4 py-2 rounded"
+            onClick={handleRun}
+            disabled={isRunning}
+          >
+            {isRunning ? 'Running...' : 'Run Mission'}
+          </button>
+        </div>
+      </section>
+
+      {plan && (
+        <section className="space-y-2 p-4 border rounded">
+          <h2 className="font-semibold">Mission Plan</h2>
+          <p className="text-sm text-gray-700">{plan.summary}</p>
+          <div className="space-y-1">
+            {plan.subtasks.map((subtask) => (
+              <div key={subtask.id} className="border rounded p-2">
+                <div className="font-semibold">{subtask.description}</div>
+                <div className="text-xs text-gray-600">Agent: {subtask.agent}</div>
+                {subtask.dependsOn?.length ? (
+                  <div className="text-xs text-gray-500">Depends on: {subtask.dependsOn.join(', ')}</div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+          {plan.orchestrationGraph?.edges?.length ? (
+            <pre className="bg-gray-50 p-2 text-xs overflow-auto">
+              {JSON.stringify(plan.orchestrationGraph, null, 2)}
+            </pre>
+          ) : null}
+        </section>
+      )}
+
+      {result && (
+        <section className="space-y-2 p-4 border rounded">
+          <h2 className="font-semibold">Execution Result</h2>
+          <div className="text-sm">Status: {result.success ? 'Success' : 'Issues detected'}</div>
+          {result.issues?.length ? (
+            <ul className="list-disc list-inside text-sm text-red-700">
+              {result.issues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          ) : null}
+          <pre className="bg-gray-50 p-2 text-xs overflow-auto">
+            {JSON.stringify(result.results, null, 2)}
+          </pre>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/docs/dev/global-orchestrator.md
+++ b/docs/dev/global-orchestrator.md
@@ -1,0 +1,69 @@
+# Global Orchestrator
+
+The global orchestrator is the mission-level planner and execution engine that coordinates specialist agents (browser, marketing, clinical, self-healing, and shadow mode).
+
+## Concepts
+- **Mission**: A high-level user intent describing an outcome. Missions are typed and include constraints, permissions, and context.
+- **Subtask**: A routable unit of work assigned to a specialist agent with optional tool hints and dependencies.
+- **Mission Plan**: Structured list of subtasks plus orchestration graph describing ordering/dependencies.
+- **Mission Result**: Aggregated results, logs, and issues after execution.
+
+## Files
+- `src/server/orchestrator/orchestratorTypes.ts` – Types for missions, plans, subtasks, and results.
+- `src/server/orchestrator/missionRegistry.ts` – Templates for common mission types.
+- `src/server/orchestrator/context.ts` – Builder for mission context (brand profile, safety flags, tool availability).
+- `src/server/orchestrator/planner.ts` – Planner that seeds subtasks, validates constraints, and shapes orchestration graphs.
+- `src/server/orchestrator/executor.ts` – Execution loop with dependency ordering, safety checks, and agent routing.
+- `src/server/orchestrator/agentRouter.ts` – Routes subtasks to the right agent family with basic fallbacks.
+- `src/server/orchestrator/index.ts` – Convenience exports and end-to-end run helper.
+
+## Missions & Templates
+Mission templates live in `missionRegistry.ts` and outline input schema, suggested subtasks, and permissions. Use `listMissionTemplates()` to enumerate options and `seedPlanFromTemplate()` to pre-populate plans.
+
+### Example Mission Requests
+```ts
+{
+  id: 'mission-001',
+  userId: 'user-123',
+  type: 'marketing.campaign',
+  goal: 'Launch a back-to-school TikTok blitz',
+  brandId: 'brand-789',
+  constraints: { budget: 5000 }
+}
+```
+
+### Example Mission Plan
+```ts
+{
+  missionId: 'mission-001',
+  summary: 'Launch a back-to-school TikTok blitz',
+  subtasks: [
+    { id: 'mission-001-seed-1', agent: 'marketing', description: 'Draft campaign creative options', tool: 'marketing.generate_campaign' },
+    { id: 'mission-001-seed-2', agent: 'browser', description: 'Research competitor positioning', tool: 'browser.plan' },
+    { id: 'mission-001-seed-3', agent: 'marketing', description: 'Assemble final campaign brief', tool: 'marketing.compile_brief', dependsOn: ['mission-001-seed-1', 'mission-001-seed-2'] }
+  ],
+  orchestrationGraph: { nodes: [], edges: [] }
+}
+```
+
+### Example Mission Result
+```ts
+{
+  missionId: 'mission-001',
+  success: true,
+  results: { /* subtask keyed responses */ },
+  issues: [],
+  logs: ['Executed mission-001-seed-1 with agent marketing']
+}
+```
+
+## Safety & Permissions
+- Marketing subtasks block PHI-related descriptions.
+- Mission constraint validation surfaces guardrail warnings.
+- `executeMissionPlan` respects plan issues and short-circuits blocked steps.
+
+## Extending
+- Add a new mission template to `missionRegistry.ts` with suggested subtasks and permissions.
+- Enhance `buildMissionContext` to pull real brand/persona data, tool availability, and healing memory.
+- Expand `routeToAgent` with real MCP calls and recovery paths.
+- Wire orchestrator MCP tools (`orchestrator.plan`, `orchestrator.run`, `orchestrator.status`, `orchestrator.list_missions`) to your tool execution layer.

--- a/docs/dev/voice-command-mode.md
+++ b/docs/dev/voice-command-mode.md
@@ -1,0 +1,36 @@
+# Voice Command Mode
+
+Voice Command Mode lets you speak missions directly to the orchestrator. Audio is captured in the dashboard, transcribed, mapped to a `MissionRequest`, planned or executed, and summarized back via optional TTS.
+
+## Flow
+1. **Capture** microphone audio with the dashboard mic control.
+2. **Transcribe** audio through `transcribeAudio` (pluggable STT provider).
+3. **Interpret** transcript into a mission using `interpretVoiceCommand`.
+4. **Plan/Run** via `handleVoiceCommand` (delegates to orchestrator planner/executor).
+5. **Respond** with a text summary and optional TTS playback served from `/api/voice/audio/[id]`.
+
+## Key Files
+- `src/server/voice/voiceTypes.ts` — shared types for voice commands and responses.
+- `src/server/voice/sttClient.ts` — STT abstraction (wire to Whisper, Google STT, etc.).
+- `src/server/voice/ttsClient.ts` — TTS abstraction (wire to ElevenLabs, Google TTS, etc.).
+- `src/server/voice/voiceInterpreter.ts` — maps transcripts to `MissionRequest` objects.
+- `src/server/voice/voiceOrchestrator.ts` — end-to-end handler to plan/run missions from voice.
+- `dashboard/app/api/voice/command/route.ts` — API endpoint to ingest audio and trigger voice handling.
+- `dashboard/app/api/voice/audio/[id]/route.ts` — serves synthesized audio from memory.
+- `dashboard/app/dev/orchestrator/page.tsx` — UI with mic control, status, transcript, and playback.
+
+## Configuration
+- Swap the placeholder STT/TTS implementations by updating `transcribeAudio` and `synthesizeSpeech` to call your provider SDKs.
+- Enforce SAFE_MODE or SIMULATION_MODE by passing `simulate=true` or gating publish actions in the orchestrator.
+- Provide user/brand/practice context to `/api/voice/command` form data so missions inherit tenant boundaries.
+
+## Example Commands
+- "Plan a 7-day TikTok campaign about GLP-1 and metabolic resets for clinicians, using my existing b-roll."
+- "Pull yesterday's YouTube Shorts analytics and summarize performance."
+- "Run a quick system health check."
+- "Onboard a new direct primary care practice in Kentucky."
+
+## Safety
+- Voice-triggered publishing should route to review queues unless explicitly permitted.
+- Clinical/PHI-sensitive data should never be sent to marketing agents; the orchestrator continues to enforce permissions.
+- Provide clear UI states (listening → processing → responding) to avoid accidental captures.

--- a/src/server/orchestrator/agentRouter.ts
+++ b/src/server/orchestrator/agentRouter.ts
@@ -1,0 +1,65 @@
+import { Subtask } from './orchestratorTypes';
+
+async function runBrowserAgent(subtask: Subtask) {
+  return {
+    success: true,
+    agent: 'browser',
+    detail: `Planned browser actions for ${subtask.description}`,
+  };
+}
+
+async function runMarketingAgent(subtask: Subtask) {
+  return {
+    success: true,
+    agent: 'marketing',
+    detail: `Generated marketing output for ${subtask.description}`,
+  };
+}
+
+async function runClinicalAgent(subtask: Subtask) {
+  return {
+    success: true,
+    agent: 'clinical',
+    detail: `Consulted clinical tools for ${subtask.description}`,
+  };
+}
+
+async function runSelfHealing(subtask: Subtask) {
+  return {
+    success: true,
+    agent: 'selfhealing',
+    detail: `Self-healing supervisor inspected ${subtask.description}`,
+  };
+}
+
+async function runShadowAgent(subtask: Subtask) {
+  return {
+    success: true,
+    agent: 'shadow',
+    detail: `Shadow session recorded for ${subtask.description}`,
+  };
+}
+
+export async function routeToAgent(subtask: Subtask): Promise<any> {
+  try {
+    switch (subtask.agent) {
+      case 'browser':
+        return await runBrowserAgent(subtask);
+      case 'marketing':
+        return await runMarketingAgent(subtask);
+      case 'clinical':
+        return await runClinicalAgent(subtask);
+      case 'selfhealing':
+        return await runSelfHealing(subtask);
+      case 'shadow':
+        return await runShadowAgent(subtask);
+      default:
+        return { success: false, error: `Unknown agent ${subtask.agent}` };
+    }
+  } catch (error: any) {
+    if (subtask.agent !== 'selfhealing') {
+      return runSelfHealing({ ...subtask, agent: 'selfhealing' });
+    }
+    return { success: false, error: error?.message || 'Routing failed' };
+  }
+}

--- a/src/server/orchestrator/context.ts
+++ b/src/server/orchestrator/context.ts
@@ -1,0 +1,61 @@
+import { MissionRequest } from './orchestratorTypes';
+
+interface ToolAvailability {
+  available: string[];
+  degraded: string[];
+}
+
+interface MissionContext {
+  brandProfile?: Record<string, any>;
+  personaProfile?: Record<string, any>;
+  toolAvailability: ToolAvailability;
+  safety: {
+    safeMode: boolean;
+    simulationMode: boolean;
+    tenantBoundaries: { brandId?: string; practiceId?: string };
+    bannedAgents?: string[];
+  };
+  analytics?: Record<string, any>;
+  healingMemory?: Record<string, any>;
+  calendar?: Record<string, any>;
+  recentMissions?: any[];
+  constraints?: Record<string, unknown>;
+}
+
+export async function buildMissionContext(
+  request: MissionRequest
+): Promise<Record<string, any>> {
+  const { brandId, practiceId } = request;
+
+  // Placeholder hooks for future integrations
+  const brandProfile = brandId
+    ? { id: brandId, tone: 'default', approvalsRequired: true }
+    : undefined;
+  const personaProfile = brandProfile
+    ? { audience: 'general', guardrails: ['no-phi', 'respect-consent'] }
+    : undefined;
+
+  const toolAvailability: ToolAvailability = {
+    available: ['browser.plan', 'browser.run', 'marketing.generate_campaign'],
+    degraded: ['clinical.search'],
+  };
+
+  const missionContext: MissionContext = {
+    brandProfile,
+    personaProfile,
+    toolAvailability,
+    safety: {
+      safeMode: true,
+      simulationMode: false,
+      tenantBoundaries: { brandId, practiceId },
+      bannedAgents: [],
+    },
+    analytics: { lastCampaign: { status: 'ok' } },
+    healingMemory: { brittleSelectors: ['#legacy-button'] },
+    calendar: { timezone: 'UTC' },
+    recentMissions: [],
+    constraints: request.constraints,
+  };
+
+  return missionContext;
+}

--- a/src/server/orchestrator/executor.ts
+++ b/src/server/orchestrator/executor.ts
@@ -1,0 +1,64 @@
+import { routeToAgent } from './agentRouter';
+import { MissionPlan, MissionResult, Subtask } from './orchestratorTypes';
+
+function topologicalSort(subtasks: Subtask[]): Subtask[] {
+  const visited = new Set<string>();
+  const result: Subtask[] = [];
+
+  function visit(task: Subtask) {
+    if (visited.has(task.id)) return;
+    visited.add(task.id);
+    (task.dependsOn || [])
+      .map((id) => subtasks.find((t) => t.id === id))
+      .filter(Boolean)
+      .forEach((dependency) => visit(dependency!));
+    result.push(task);
+  }
+
+  subtasks.forEach((task) => visit(task));
+  return result;
+}
+
+function checkAgentPermission(subtask: Subtask, plan: MissionPlan) {
+  if (plan.issues?.length) {
+    return { allowed: false, reason: plan.issues.join('; ') };
+  }
+  if (subtask.agent === 'marketing' && subtask.description.toLowerCase().includes('phi')) {
+    return { allowed: false, reason: 'Marketing agents cannot access PHI.' };
+  }
+  return { allowed: true };
+}
+
+export async function executeMissionPlan(plan: MissionPlan): Promise<MissionResult> {
+  const orderedSubtasks = topologicalSort(plan.subtasks);
+  const logs: string[] = [];
+  const results: Record<string, unknown> = {};
+  const issues: string[] = [];
+
+  for (const subtask of orderedSubtasks) {
+    const permission = checkAgentPermission(subtask, plan);
+    if (!permission.allowed) {
+      issues.push(`Blocked ${subtask.id}: ${permission.reason}`);
+      continue;
+    }
+
+    try {
+      const result = await routeToAgent(subtask);
+      results[subtask.id] = result;
+      if (!result?.success) {
+        issues.push(`Subtask ${subtask.id} failed: ${result?.error || 'unknown error'}`);
+      }
+      logs.push(`Executed ${subtask.id} with agent ${subtask.agent}`);
+    } catch (error: any) {
+      issues.push(`Subtask ${subtask.id} threw: ${error?.message || 'unknown error'}`);
+    }
+  }
+
+  return {
+    missionId: plan.missionId,
+    success: issues.length === 0,
+    results,
+    issues,
+    logs,
+  };
+}

--- a/src/server/orchestrator/index.ts
+++ b/src/server/orchestrator/index.ts
@@ -1,0 +1,20 @@
+import { buildMissionContext } from './context';
+import { executeMissionPlan } from './executor';
+import { planMission } from './planner';
+import { listMissionTemplates } from './missionRegistry';
+import { MissionRequest, MissionResult } from './orchestratorTypes';
+
+export async function runMission(request: MissionRequest): Promise<MissionResult> {
+  const context = request.context || (await buildMissionContext(request));
+  const plan = await planMission({ ...request, context });
+  return executeMissionPlan(plan);
+}
+
+export async function orchestratorStatus() {
+  return {
+    recent: [],
+    health: 'ok',
+  };
+}
+
+export { planMission, executeMissionPlan, buildMissionContext, listMissionTemplates };

--- a/src/server/orchestrator/missionRegistry.ts
+++ b/src/server/orchestrator/missionRegistry.ts
@@ -1,0 +1,161 @@
+import { MissionRequest, MissionType, Subtask } from './orchestratorTypes';
+
+export interface MissionTemplate {
+  type: MissionType;
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  suggestedSubtasks: Omit<Subtask, 'id'>[];
+  requiredPermissions: string[];
+}
+
+export const missionTemplates: MissionTemplate[] = [
+  {
+    type: 'marketing.campaign',
+    name: 'Launch marketing campaign',
+    description: 'Plan and launch a multi-channel marketing campaign with approvals.',
+    inputSchema: {
+      goal: 'Campaign goal or KPI',
+      budget: 'Optional budget constraints',
+      channels: 'Preferred channels',
+    },
+    suggestedSubtasks: [
+      { agent: 'marketing', description: 'Draft campaign creative options', tool: 'marketing.generate_campaign' },
+      { agent: 'browser', description: 'Research competitor positioning', tool: 'browser.plan' },
+      { agent: 'marketing', description: 'Assemble final campaign brief', tool: 'marketing.compile_brief' },
+    ],
+    requiredPermissions: ['marketing:plan', 'browser:read'],
+  },
+  {
+    type: 'marketing.daily_content',
+    name: 'Daily content plan',
+    description: 'Generate and schedule daily social posts with media sourcing.',
+    inputSchema: {
+      cadence: 'Posting frequency',
+      tone: 'Brand voice cues',
+    },
+    suggestedSubtasks: [
+      { agent: 'marketing', description: 'Generate post ideas', tool: 'marketing.generate_daily' },
+      { agent: 'browser', description: 'Identify trending audio or hashtags', tool: 'browser.plan' },
+      { agent: 'marketing', description: 'Assemble schedule with captions', tool: 'marketing.schedule' },
+    ],
+    requiredPermissions: ['marketing:plan', 'browser:read'],
+  },
+  {
+    type: 'analytics.youtube',
+    name: 'YouTube analytics',
+    description: 'Gather performance metrics and summarize insights.',
+    inputSchema: {
+      channel: 'Channel handle',
+    },
+    suggestedSubtasks: [
+      { agent: 'browser', description: 'Collect analytics from dashboard', tool: 'browser.plan' },
+      { agent: 'marketing', description: 'Summarize insights and opportunities', tool: 'marketing.summarize' },
+    ],
+    requiredPermissions: ['browser:read'],
+  },
+  {
+    type: 'analytics.tiktok',
+    name: 'TikTok analytics',
+    description: 'Collect TikTok metrics and propose experiments.',
+    inputSchema: {
+      handle: 'TikTok account handle',
+    },
+    suggestedSubtasks: [
+      { agent: 'browser', description: 'Collect performance metrics', tool: 'browser.plan' },
+      { agent: 'marketing', description: 'Generate recommendations', tool: 'marketing.summarize' },
+    ],
+    requiredPermissions: ['browser:read'],
+  },
+  {
+    type: 'clinical.research',
+    name: 'Clinical research',
+    description: 'Research clinical topics using RAG and literature tools.',
+    inputSchema: {
+      topic: 'Clinical topic or question',
+      practiceId: 'Optional practice context',
+    },
+    suggestedSubtasks: [
+      { agent: 'clinical', description: 'Retrieve clinical evidence', tool: 'clinical.search' },
+      { agent: 'clinical', description: 'Summarize findings', tool: 'clinical.summarize' },
+    ],
+    requiredPermissions: ['clinical:read'],
+  },
+  {
+    type: 'clinical.pathway',
+    name: 'Clinical pathway planning',
+    description: 'Draft a care pathway with decision points.',
+    inputSchema: {
+      condition: 'Target condition',
+      practiceId: 'Practice identifier',
+    },
+    suggestedSubtasks: [
+      { agent: 'clinical', description: 'Draft pathway', tool: 'clinical.pathway' },
+      { agent: 'shadow', description: 'Record pathway execution data', tool: 'shadow.start_session' },
+    ],
+    requiredPermissions: ['clinical:write'],
+  },
+  {
+    type: 'onboarding.practice',
+    name: 'Practice onboarding',
+    description: 'Set up a new practice instance with guardrails.',
+    inputSchema: {
+      practiceName: 'Name of practice',
+      owner: 'Primary contact',
+    },
+    suggestedSubtasks: [
+      { agent: 'selfhealing', description: 'Check platform health', tool: 'healing.run_supervisor' },
+      { agent: 'marketing', description: 'Load brand defaults', tool: 'marketing.load_brand' },
+      { agent: 'browser', description: 'Validate external integrations', tool: 'browser.plan' },
+    ],
+    requiredPermissions: ['system:setup', 'browser:read'],
+  },
+  {
+    type: 'system.self_heal',
+    name: 'Self-heal failing flows',
+    description: 'Audit broken flows and apply patches.',
+    inputSchema: {
+      incident: 'Recent incident identifier',
+    },
+    suggestedSubtasks: [
+      { agent: 'selfhealing', description: 'Diagnose failure signatures', tool: 'healing.run_supervisor' },
+      { agent: 'browser', description: 'Replay failing workflow', tool: 'browser.plan' },
+    ],
+    requiredPermissions: ['system:heal'],
+  },
+  {
+    type: 'system.shadow_learn',
+    name: 'Shadow learn new workflow',
+    description: 'Record human workflow to learn selectors and patterns.',
+    inputSchema: {
+      flow: 'Flow identifier',
+    },
+    suggestedSubtasks: [
+      { agent: 'shadow', description: 'Begin recording session', tool: 'shadow.start_session' },
+      { agent: 'shadow', description: 'Summarize captured actions', tool: 'shadow.summarize' },
+    ],
+    requiredPermissions: ['system:shadow'],
+  },
+];
+
+export function getMissionTemplate(type: MissionType) {
+  return missionTemplates.find((template) => template.type === type);
+}
+
+export function listMissionTemplates() {
+  return missionTemplates.map((template) => ({
+    type: template.type,
+    name: template.name,
+    description: template.description,
+  }));
+}
+
+export function seedPlanFromTemplate(request: MissionRequest): Subtask[] {
+  const template = getMissionTemplate(request.type);
+  if (!template) return [];
+
+  return template.suggestedSubtasks.map((subtask, index) => ({
+    ...subtask,
+    id: `${request.id}-seed-${index + 1}`,
+  }));
+}

--- a/src/server/orchestrator/orchestratorTypes.ts
+++ b/src/server/orchestrator/orchestratorTypes.ts
@@ -1,0 +1,47 @@
+export type MissionType =
+  | 'marketing.campaign'
+  | 'marketing.daily_content'
+  | 'analytics.youtube'
+  | 'analytics.tiktok'
+  | 'clinical.research'
+  | 'clinical.pathway'
+  | 'onboarding.practice'
+  | 'system.self_heal'
+  | 'system.shadow_learn'
+  | 'custom';
+
+export interface MissionRequest {
+  id: string;
+  userId: string;
+  brandId?: string;
+  practiceId?: string;
+  type: MissionType;
+  goal: string;
+  constraints?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface Subtask {
+  id: string;
+  agent: string;
+  description: string;
+  tool?: string;
+  input?: any;
+  dependsOn?: string[];
+}
+
+export interface MissionPlan {
+  missionId: string;
+  summary: string;
+  subtasks: Subtask[];
+  orchestrationGraph: any;
+  issues?: string[];
+}
+
+export interface MissionResult {
+  missionId: string;
+  success: boolean;
+  results: Record<string, unknown>;
+  issues?: string[];
+  logs?: string[];
+}

--- a/src/server/orchestrator/planner.ts
+++ b/src/server/orchestrator/planner.ts
@@ -1,0 +1,75 @@
+import { buildMissionContext } from './context';
+import {
+  MissionPlan,
+  MissionRequest,
+  Subtask,
+} from './orchestratorTypes';
+import { seedPlanFromTemplate } from './missionRegistry';
+
+function generateOrchestrationGraph(subtasks: Subtask[]) {
+  return {
+    nodes: subtasks.map((task) => ({ id: task.id, label: task.description })),
+    edges: subtasks.flatMap((task) =>
+      (task.dependsOn || []).map((dependency) => ({ from: dependency, to: task.id }))
+    ),
+  };
+}
+
+function validateConstraints(request: MissionRequest, context: Record<string, any>) {
+  const issues: string[] = [];
+  if (context.safety?.safeMode && request.type.startsWith('clinical')) {
+    issues.push('Clinical workflows running in safe mode may be read-only.');
+  }
+  if (request.constraints?.budget && Number(request.constraints.budget) > 100000) {
+    issues.push('Budget exceeds default guardrail.');
+  }
+  return issues;
+}
+
+function enrichSubtasksWithContext(subtasks: Subtask[], context: Record<string, any>) {
+  return subtasks.map((subtask) => ({
+    ...subtask,
+    input: {
+      ...(subtask.input || {}),
+      brandProfile: context.brandProfile,
+      personaProfile: context.personaProfile,
+      analytics: context.analytics,
+    },
+  }));
+}
+
+export async function planMission(request: MissionRequest): Promise<MissionPlan> {
+  const context = request.context || (await buildMissionContext(request));
+  const seededSubtasks = seedPlanFromTemplate(request);
+
+  const defaultSubtasks: Subtask[] = seededSubtasks.length
+    ? seededSubtasks
+    : [
+        {
+          id: `${request.id}-browser-assess`,
+          agent: 'browser',
+          description: 'Perform reconnaissance to collect signals',
+          tool: 'browser.plan',
+        },
+        {
+          id: `${request.id}-report`,
+          agent: 'marketing',
+          description: 'Summarize findings for user review',
+          tool: 'marketing.summarize',
+          dependsOn: [`${request.id}-browser-assess`],
+        },
+      ];
+
+  const subtasks = enrichSubtasksWithContext(defaultSubtasks, context);
+  const issues = validateConstraints(request, context);
+  const orchestrationGraph = generateOrchestrationGraph(subtasks);
+
+  return {
+    missionId: request.id,
+    summary:
+      request.goal || 'Mission requested. Subtasks generated with available templates.',
+    subtasks,
+    orchestrationGraph,
+    issues,
+  } as MissionPlan;
+}

--- a/src/server/voice/audioStore.ts
+++ b/src/server/voice/audioStore.ts
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+
+const audioStore = new Map<string, { buffer: Buffer; mimeType: string }>();
+
+export function saveAudioBuffer(buffer: Buffer, mimeType: string): string {
+  const id = crypto.randomUUID();
+  audioStore.set(id, { buffer, mimeType });
+  return id;
+}
+
+export function getAudioBuffer(id: string): { buffer: Buffer; mimeType: string } | null {
+  return audioStore.get(id) ?? null;
+}

--- a/src/server/voice/sttClient.ts
+++ b/src/server/voice/sttClient.ts
@@ -1,0 +1,17 @@
+export interface STTResult {
+  text: string;
+  confidence?: number;
+  raw?: unknown;
+}
+
+export async function transcribeAudio(
+  audioBuffer: Buffer,
+  options?: { language?: string; prompt?: string }
+): Promise<STTResult> {
+  const promptHint = options?.prompt ? ` prompt="${options.prompt}"` : '';
+  return {
+    text: '[transcription placeholder]',
+    confidence: 0.0,
+    raw: { bytes: audioBuffer.length, language: options?.language, prompt: promptHint },
+  };
+}

--- a/src/server/voice/ttsClient.ts
+++ b/src/server/voice/ttsClient.ts
@@ -1,0 +1,18 @@
+export interface TTSResult {
+  audioBuffer: Buffer;
+  mimeType: string;
+}
+
+export async function synthesizeSpeech(
+  text: string,
+  options?: { voiceId?: string; speakingStyle?: string }
+): Promise<TTSResult | null> {
+  if (!text.trim()) {
+    return null;
+  }
+
+  return {
+    audioBuffer: Buffer.from(text, 'utf-8'),
+    mimeType: 'audio/wav',
+  };
+}

--- a/src/server/voice/voiceInterpreter.ts
+++ b/src/server/voice/voiceInterpreter.ts
@@ -1,0 +1,74 @@
+import { MissionRequest, MissionType } from '../orchestrator/orchestratorTypes';
+import { VoiceCommand } from './voiceTypes';
+
+function classifyMissionType(transcript: string): { type: MissionType; rationale: string } {
+  const text = transcript.toLowerCase();
+
+  if (text.includes('self heal') || text.includes('health check') || text.includes('repair')) {
+    return { type: 'system.self_heal', rationale: 'Detected request for system health or repair.' };
+  }
+
+  if (text.includes('shadow')) {
+    return { type: 'system.shadow_learn', rationale: 'Mentions shadow learning or observation.' };
+  }
+
+  if (text.includes('onboard') || text.includes('new practice')) {
+    return { type: 'onboarding.practice', rationale: 'References onboarding a practice.' };
+  }
+
+  if (text.includes('clinical') || text.includes('pathway')) {
+    return { type: 'clinical.pathway', rationale: 'Clinical pathway or workflow mentioned.' };
+  }
+
+  if (text.includes('research') || text.includes('study')) {
+    return { type: 'clinical.research', rationale: 'Research-oriented language detected.' };
+  }
+
+  if (text.includes('analytics') || text.includes('report') || text.includes('metrics')) {
+    if (text.includes('youtube')) {
+      return { type: 'analytics.youtube', rationale: 'Analytics tied to YouTube requested.' };
+    }
+    if (text.includes('tiktok')) {
+      return { type: 'analytics.tiktok', rationale: 'Analytics tied to TikTok requested.' };
+    }
+    return { type: 'analytics.youtube', rationale: 'Analytics requested; defaulting to YouTube analytics.' };
+  }
+
+  if (text.includes('daily') || text.includes('every day')) {
+    return { type: 'marketing.daily_content', rationale: 'Daily cadence implied in transcript.' };
+  }
+
+  if (text.includes('campaign') || text.includes('week') || text.includes('plan')) {
+    return { type: 'marketing.campaign', rationale: 'Campaign or planning keywords detected.' };
+  }
+
+  return { type: 'custom', rationale: 'Defaulted to custom mission type.' };
+}
+
+export async function interpretVoiceCommand(cmd: VoiceCommand): Promise<MissionRequest> {
+  const { type, rationale } = classifyMissionType(cmd.transcript);
+  const mission: MissionRequest = {
+    id: `mission-${cmd.id}`,
+    userId: cmd.userId,
+    brandId: cmd.brandId,
+    practiceId: cmd.practiceId,
+    type,
+    goal: cmd.transcript.trim(),
+    constraints: {},
+    context: {
+      source: 'voice',
+      rationale,
+      rawTranscript: cmd.transcript,
+      voiceContext: cmd.context,
+    },
+  };
+
+  if (cmd.context?.lastMissionId) {
+    mission.context = {
+      ...mission.context,
+      followupTo: cmd.context.lastMissionId,
+    };
+  }
+
+  return mission;
+}

--- a/src/server/voice/voiceOrchestrator.ts
+++ b/src/server/voice/voiceOrchestrator.ts
@@ -1,0 +1,73 @@
+import { buildMissionContext, executeMissionPlan, planMission } from '../orchestrator';
+import { MissionPlan, MissionRequest, MissionResult } from '../orchestrator/orchestratorTypes';
+import { saveAudioBuffer } from './audioStore';
+import { synthesizeSpeech } from './ttsClient';
+import { interpretVoiceCommand } from './voiceInterpreter';
+import { VoiceCommand, VoiceResponse } from './voiceTypes';
+
+function summarizePlan(plan: MissionPlan): string {
+  const agentCounts = plan.subtasks.reduce<Record<string, number>>((acc, task) => {
+    acc[task.agent] = (acc[task.agent] || 0) + 1;
+    return acc;
+  }, {});
+  const primaryAgents = Object.entries(agentCounts)
+    .map(([agent, count]) => `${agent} x${count}`)
+    .join(', ');
+  return `Planned ${plan.subtasks.length} steps across ${primaryAgents || 'agents'}: ${plan.summary}`;
+}
+
+function summarizeResult(plan: MissionPlan, result: MissionResult): string {
+  if (!result.success) {
+    return `Mission ${plan.missionId} encountered issues: ${(result.issues || []).join('; ') || 'see logs'}`;
+  }
+  return `Mission ${plan.missionId} completed with ${Object.keys(result.results).length} result entries.`;
+}
+
+export async function handleVoiceCommand(
+  cmd: VoiceCommand,
+  options?: { mode?: 'plan' | 'run'; simulate?: boolean }
+): Promise<VoiceResponse> {
+  const mode = options?.mode ?? 'plan';
+  const mission = await interpretVoiceCommand(cmd);
+  const missionWithContext: MissionRequest = {
+    ...mission,
+    context: mission.context || (await buildMissionContext(mission)),
+  };
+
+  if (options?.simulate) {
+    missionWithContext.context = {
+      ...missionWithContext.context,
+      simulation: true,
+    };
+  }
+
+  let plan: MissionPlan | null = null;
+  let missionResult: MissionResult | null = null;
+
+  if (mode === 'plan') {
+    plan = await planMission(missionWithContext);
+  } else {
+    plan = await planMission(missionWithContext);
+    missionResult = await executeMissionPlan(plan);
+  }
+
+  const summary = missionResult
+    ? summarizeResult(plan, missionResult)
+    : plan
+      ? summarizePlan(plan)
+      : 'No plan generated.';
+
+  const tts = await synthesizeSpeech(summary, {});
+  const ttsUrl = tts ? `/api/voice/audio/${saveAudioBuffer(tts.audioBuffer, tts.mimeType)}` : undefined;
+
+  return {
+    commandId: cmd.id,
+    missionId: plan?.missionId ?? mission.id,
+    transcriptSummary: summary,
+    ttsUrl,
+    followupHints: [
+      'Try: "Make that campaign longer"',
+      'Ask: "Run in simulation mode first"',
+    ],
+  };
+}

--- a/src/server/voice/voiceTypes.ts
+++ b/src/server/voice/voiceTypes.ts
@@ -1,0 +1,24 @@
+export type VoiceSessionState = 'idle' | 'listening' | 'processing' | 'responding';
+
+export interface VoiceCommand {
+  id: string;
+  userId: string;
+  brandId?: string;
+  practiceId?: string;
+  transcript: string;
+  createdAt: string;
+  context?: Record<string, unknown>;
+}
+
+export interface VoiceResponse {
+  commandId: string;
+  missionId?: string;
+  transcriptSummary: string;
+  ttsUrl?: string;
+  followupHints?: string[];
+}
+
+export interface VoiceMissionMapping {
+  command: VoiceCommand;
+  mission: import('../orchestrator/orchestratorTypes').MissionRequest;
+}

--- a/types.ts
+++ b/types.ts
@@ -401,6 +401,52 @@ export const nativeTools: FunctionDeclaration[] = [
         parameters: { type: Type.OBJECT, properties: {} },
     },
     {
+        name: 'orchestrator.plan',
+        description: 'Generate a mission plan for a high-level goal across agents.',
+        parameters: {
+            type: Type.OBJECT,
+            properties: {
+                id: { type: Type.STRING, description: 'Mission identifier' },
+                userId: { type: Type.STRING, description: 'Requesting user identifier' },
+                type: { type: Type.STRING, description: 'Mission type key' },
+                goal: { type: Type.STRING, description: 'Natural language mission intent' },
+                brandId: { type: Type.STRING, description: 'Optional brand ID' },
+                practiceId: { type: Type.STRING, description: 'Optional practice ID' },
+                constraints: { type: Type.OBJECT, description: 'Constraint object' },
+                context: { type: Type.OBJECT, description: 'Prebuilt mission context' },
+            },
+            required: ['id', 'userId', 'type', 'goal'],
+        },
+    },
+    {
+        name: 'orchestrator.run',
+        description: 'Plan and execute a mission, returning results.',
+        parameters: {
+            type: Type.OBJECT,
+            properties: {
+                id: { type: Type.STRING, description: 'Mission identifier' },
+                userId: { type: Type.STRING, description: 'Requesting user identifier' },
+                type: { type: Type.STRING, description: 'Mission type key' },
+                goal: { type: Type.STRING, description: 'Natural language mission intent' },
+                brandId: { type: Type.STRING, description: 'Optional brand ID' },
+                practiceId: { type: Type.STRING, description: 'Optional practice ID' },
+                constraints: { type: Type.OBJECT, description: 'Constraint object' },
+                context: { type: Type.OBJECT, description: 'Prebuilt mission context' },
+            },
+            required: ['id', 'userId', 'type', 'goal'],
+        },
+    },
+    {
+        name: 'orchestrator.status',
+        description: 'Return recent mission status, logs, and outcomes.',
+        parameters: { type: Type.OBJECT, properties: {} },
+    },
+    {
+        name: 'orchestrator.list_missions',
+        description: 'List predefined mission templates and metadata.',
+        parameters: { type: Type.OBJECT, properties: {} },
+    },
+    {
         name: 'task_completed',
         description: 'Call this function when you have fully completed the user\'s request.',
         parameters: {


### PR DESCRIPTION
## Summary
- add voice types, STT/TTS abstractions, interpreter, and orchestrator wrapper for voice missions
- expose voice command and audio playback API routes plus an in-memory audio store
- integrate mic UX into the orchestrator dashboard and document voice command mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de5e443188324b1421ac8e4dd832a)