### PR TITLE
Add smoke test workflow for browser and orchestrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: Core CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main", "dev"]
+
+jobs:
+  build-and-verify:
+    name: Install, Lint, Typecheck, Test, Build, QA
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run lint (if present)
+        run: |
+          if node -e "const s=require('./package.json').scripts||{}; process.exit(s.lint?0:1)"; then
+            echo "Lint script found; running pnpm lint"
+            pnpm lint
+          else
+            echo "No lint script found; skipping lint"
+          fi
+
+      - name: Run type checks (typecheck or ts:check)
+        run: |
+          SCRIPT=$(node -e "const s=require('./package.json').scripts||{}; if(s['typecheck']){console.log('typecheck');} else if(s['ts:check']){console.log('ts:check');} else process.exit(1);") || true
+          if [ -n "$SCRIPT" ]; then
+            echo "Running pnpm $SCRIPT"
+            pnpm run "$SCRIPT"
+          else
+            echo "No typecheck/ts:check script found; skipping type checks"
+          fi
+
+      - name: Run tests (if present)
+        run: |
+          if node -e "const s=require('./package.json').scripts||{}; process.exit(s.test?0:1)"; then
+            echo "Test script found; running pnpm test"
+            pnpm test
+          else
+            echo "No test script found; skipping tests"
+          fi
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Run smoke tests (qa:smoke if present)
+        run: |
+          if node -e "const s=require('./package.json').scripts||{}; process.exit(s['qa:smoke']?0:1)"; then
+            echo "Smoke test script found; running pnpm qa:smoke"
+            pnpm run qa:smoke
+          else
+            echo "No qa:smoke script found; skipping smoke tests"
+          fi

--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -1,0 +1,94 @@
+name: Nightly Maintenance Health Check
+
+on:
+  schedule:
+    # 06:00 UTC is 01:00 ET (nightly)
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly-health:
+    name: Run nightly maintenance and health audit
+    runs-on: ubuntu-latest
+    env:
+      SAFE_MODE: "true"
+      SIMULATION_MODE: "true"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run self-healing supervisor (healing:run-supervisor)
+        run: |
+          if node -e "const s=require('./package.json').scripts||{}; process.exit(s['healing:run-supervisor']?0:1)"; then
+            echo "Launching self-healing supervisor in safe/simulation mode"
+            pnpm run healing:run-supervisor
+          else
+            echo "Missing healing:run-supervisor script; failing health workflow"
+            exit 1
+          fi
+
+      - name: Run orchestrator mission (system.health_audit)
+        run: |
+          if node -e "const s=require('./package.json').scripts||{}; process.exit(s['orchestrator.run']?0:1)"; then
+            echo "Running orchestrator mission in simulation mode"
+            pnpm run orchestrator.run -- --mission system.health_audit --mode simulation
+          else
+            echo "Missing orchestrator.run script; failing health workflow"
+            exit 1
+          fi
+
+      - name: Generate health report
+        id: health_report
+        run: |
+          REPORT_FILE="artifacts/system-health-$(date -u +%F).md"
+          mkdir -p artifacts
+          OVERALL_STATE="Simulation run completed; review supervisor/orchestrator logs for detailed status."
+          cat <<EOF2 > "$REPORT_FILE"
+          # Nightly System Health Report
+
+          - Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          - Mode: SAFE_MODE=${SAFE_MODE}, SIMULATION_MODE=${SIMULATION_MODE}
+
+          ## Overall Health State
+          - ${OVERALL_STATE}
+
+          ## Top 5 Recent Issues
+          - Captured from supervisor mission logs (see workflow run).
+          - Captured from orchestrator mission logs (see workflow run).
+          - (Add additional issue summaries here as automation evolves.)
+
+          ## Auto-fixes Attempted
+          - Supervisor attempted healing routines in simulation mode; see logs for actions taken.
+          - Orchestrator executed system.health_audit in simulation mode.
+          EOF2
+          echo "report_file=$REPORT_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload health report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: system-health-report
+          path: ${{ steps.health_report.outputs.report_file }}
+          if-no-files-found: error
+
+      - name: Post summary to log
+        run: |
+          echo "Health report generated at: ${{ steps.health_report.outputs.report_file }}"
+          echo "--- Report Preview ---"
+          sed -n '1,40p' "${{ steps.health_report.outputs.report_file }}"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,66 @@
+name: Smoke Tests (Browser & Orchestrator)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main", "dev"]
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  smoke:
+    name: Run smoke tests in simulation
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'needs-smoke-test') || (github.event.action == 'labeled' && github.event.label.name == 'needs-smoke-test')))
+    env:
+      SAFE_MODE: "true"
+      SIMULATION_MODE: "true"
+      CI: "true"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers (Chromium)
+        run: pnpm dlx playwright install chromium --with-deps
+
+      - name: Run browser & orchestrator smoke tests
+        run: |
+          set -euo pipefail
+          SCRIPT=$(node - <<'NODE'
+          const { scripts = {} } = require('./package.json');
+          if (scripts['qa:smoke']) {
+            console.log('qa:smoke');
+          } else if (scripts['orchestrator:smoke-test']) {
+            console.log('orchestrator:smoke-test');
+          } else {
+            console.error('Missing smoke test script. Add a qa:smoke or orchestrator:smoke-test script to package.json that visits example.com and runs a marketing.campaign mission.');
+            process.exit(1);
+          }
+          NODE
+          )
+          echo "Executing pnpm run ${SCRIPT}"
+          pnpm run "${SCRIPT}" | tee smoke-test-log.txt
+
+      - name: Upload smoke test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-log
+          path: smoke-test-log.txt
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add a dedicated smoke test workflow triggered via manual dispatch or pull requests labeled needs-smoke-test
- configure pnpm/node setup with playwright browsers, safe/simulation env vars, and required smoke script selection with clear failure messaging
- capture smoke script output into an artifact log for visibility

## Testing
- not run (workflow configuration change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de84c9f488324929a1aefebdb0b8a)