### PR TITLE
Add plugin framework manifest types and loader

### DIFF
--- a/src/browser/plugins/pluginTypes.ts
+++ b/src/browser/plugins/pluginTypes.ts
@@ -79,6 +79,13 @@ export interface PluginEntry {
   skills?: SkillPackDefinition[];
 }
 
+export interface DomainSkillMatch {
+  pluginId: string;
+  pluginName: string;
+  manifest: PluginManifest;
+  skills: SkillPackDefinition[];
+}
+
 export interface PluginModule {
   createPlugin: (context: PluginContext) => PluginEntry | Promise<PluginEntry>;
 }


### PR DESCRIPTION
## Summary
- add typed plugin manifest, skill pack, and safe API definitions for browser plugins
- implement plugin loader that validates permissions, loads manifests, and builds scoped plugin contexts
- wire domain indexing and navigation notifications to surface site-specific skill packs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dedafb10883249ef0a3067d3e5923)