### PR TITLE
Add vault snapshot skill integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pids/
 *.pid
 *.seed
 *.pid.lock
+PalmVault/
 
 # Coverage directory used by tools like istanbul
 coverage/

--- a/browser/skills/youtube.skill.json
+++ b/browser/skills/youtube.skill.json
@@ -1,0 +1,17 @@
+{
+  "id": "youtube",
+  "domain": ["youtube.com", "studio.youtube.com"],
+  "selectors": {
+    "analyticsButton": "#analytics-button",
+    "overviewTab": "#analytics-overview"
+  },
+  "workflows": {
+    "openAnalytics": [
+      { "action": "goto", "url": "https://studio.youtube.com", "description": "Navigate to Studio" },
+      { "action": "waitForSelector", "selector": "#analytics-button", "description": "Wait for analytics button" },
+      { "action": "click", "selector": "#analytics-button", "description": "Open analytics" },
+      { "action": "waitForSelector", "selector": "#analytics-overview", "description": "Load overview" },
+      { "action": "extractText", "selector": "#analytics-overview", "description": "Read overview" }
+    ]
+  }
+}

--- a/docs/dev/plugins-and-skills.md
+++ b/docs/dev/plugins-and-skills.md
@@ -1,0 +1,36 @@
+# Plugins and skills on live pages and vault snapshots
+
+The skill system can now run against both live URLs and `vault://` snapshots by sharing a common `PageContext`.
+
+## Virtual domains
+
+When a `vault://page/{id}` URL is resolved, the protocol handler reads `meta/{id}.json` to populate a `PageContext` with `virtualDomain`, `snapshotId`, and `skillHint`. The virtual domain mirrors the original host, letting the skill manager select the same skill pack used for the live site.
+
+For live pages, `PageContext.virtualDomain` falls back to the current hostname.
+
+## Skill selection
+
+`SkillManager.getActiveSkillForPage(pageContext)` now:
+
+1. Checks `skillHint` when available.
+2. Matches the virtual domain against known skill packs.
+3. Falls back to the live URL host.
+
+Skill packs live under `browser/skills/*.skill.json` and include domain metadata, selectors, and workflows. The YouTube pack example ships with an `openAnalytics` workflow used by the QA smoke test.
+
+## Snapshot-aware workflows
+
+Workflows can contain navigation and DOM actions. In snapshot mode:
+
+- `goto` steps are skipped with a log message.
+- DOM-centric steps (wait, click, extract) operate directly against the saved HTML.
+
+The `SkillWorkflowExecutor` handles these semantics, keeping behaviors aligned between live browsing and offline snapshots.
+
+## Plugin API helpers
+
+Plugins can read context and skills through `PluginAPI`:
+
+- `getPageContext()` returns `{ url, virtualDomain, snapshotId, skillHint, isVaultSnapshot }` for the active tab.
+- `vault.getSnapshotMeta(id)` and `vault.openSnapshot(id)` provide access to saved pages.
+- `skills.getActiveSkill()` returns the skill pack for the current page, regardless of whether it is live or from the vault.

--- a/docs/dev/vault-mode.md
+++ b/docs/dev/vault-mode.md
@@ -1,0 +1,49 @@
+# Vault Mode
+
+The Vault preserves offline copies of pages and keeps their original context so the agent can continue using site-specific skills when browsing snapshots.
+
+## Snapshot layout
+
+Snapshots are stored under `PalmVault`:
+
+- `pages/{id}.html` – raw HTML saved from the browser.
+- `markdown/{id}.md` – optional rendered Markdown.
+- `meta/{id}.json` – metadata including the original URL, domain, and skill hint.
+- `index.json` – lightweight listing for offline browse views.
+
+Every metadata record follows:
+
+```ts
+interface VaultSnapshotMeta {
+  id: string;
+  url: string;
+  domain: string;
+  title?: string;
+  tags?: string[];
+  createdAt: string;
+  missionId?: string;
+  skillHint?: string;
+}
+```
+
+The domain is extracted from the original URL. A `skillHint` is derived automatically for common hosts (YouTube, TikTok, Supabase) so the skills system can map snapshots back to their live site behaviors.
+
+## Page context for snapshots
+
+Opening `vault://page/{id}` yields a `PageContext` that mirrors the live browsing context:
+
+- `url`: the `vault://` location.
+- `virtualDomain`: the original host (e.g., `studio.youtube.com`).
+- `snapshotId`: the vault ID.
+- `skillHint`: the derived skill pack key when available.
+- `isVaultSnapshot`: marks offline mode.
+
+Agents and plugins can use this context to choose the correct skill pack even when browsing offline content.
+
+## Tags and filtering
+
+Snapshots are automatically tagged with `source:<domain>` and `skill:<skillHint>` (when present). The tags appear in `index.json`, enabling filters for source site or skill pack in vault UI surfaces.
+
+## Offline behavior
+
+When running skills against a snapshot, navigation steps are skipped while DOM operations continue to run on the saved HTML. This lets workflows such as YouTube analytics inspection operate without network connectivity.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean:git": "git clean -fd",
     "preview": "vite preview",
     "electron": "tsx electron/main.ts",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "qa:vault-skills": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"moduleResolution\":\"node\",\"esModuleInterop\":true}' --transpile-only tools/qa/vault-skills-smoke.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/services/pageContextManager.ts
+++ b/services/pageContextManager.ts
@@ -1,0 +1,19 @@
+import { PageContext } from './vaultProtocol';
+
+export class PageContextManager {
+  private contexts: Map<string, PageContext> = new Map();
+
+  setContext(tabId: string, context: PageContext): void {
+    this.contexts.set(tabId, context);
+  }
+
+  getContext(tabId: string): PageContext | undefined {
+    return this.contexts.get(tabId);
+  }
+
+  clear(tabId: string): void {
+    this.contexts.delete(tabId);
+  }
+}
+
+export const pageContextManager = new PageContextManager();

--- a/services/pluginAPI.ts
+++ b/services/pluginAPI.ts
@@ -1,0 +1,46 @@
+import { vaultProtocol, PageContext } from './vaultProtocol';
+import { vaultService } from './vaultService';
+import { skillManager, SkillPack } from './skillManager';
+import { pageContextManager } from './pageContextManager';
+
+interface PluginAPIOptions {
+  getActiveTabId?: () => string | null;
+  navigate?: (tabId: string, url: string) => Promise<void>;
+}
+
+export class PluginAPI {
+  constructor(private options: PluginAPIOptions = {}) {}
+
+  getPageContext(tabId?: string): PageContext | undefined {
+    const targetTab = tabId ?? this.options.getActiveTabId?.() ?? undefined;
+    if (!targetTab) return undefined;
+    return pageContextManager.getContext(targetTab);
+  }
+
+  async resolveContextForUrl(url: string): Promise<PageContext> {
+    const result = await vaultProtocol.resolve(url);
+    return result.pageContext;
+  }
+
+  readonly vault = {
+    getSnapshotMeta: (id: string) => vaultService.getSnapshotMeta(id),
+    openSnapshot: async (id: string, tabId?: string) => {
+      const url = vaultService.openSnapshot(id);
+      const targetTab = tabId ?? this.options.getActiveTabId?.();
+      if (url && targetTab && this.options.navigate) {
+        await this.options.navigate(targetTab, url);
+      }
+      return url;
+    },
+  };
+
+  readonly skills = {
+    getActiveSkill: async (tabId?: string): Promise<SkillPack | null> => {
+      const context = this.getPageContext(tabId);
+      if (!context) return null;
+      return skillManager.getActiveSkillForPage(context);
+    },
+  };
+}
+
+export const pluginAPI = new PluginAPI();

--- a/services/skillManager.ts
+++ b/services/skillManager.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { PageContext } from './vaultProtocol';
+
+export interface SkillWorkflowStep {
+  action: 'goto' | 'click' | 'waitForSelector' | 'extractText';
+  selector?: string;
+  url?: string;
+  description?: string;
+}
+
+export interface SkillPack {
+  id: string;
+  domain: string[];
+  selectors: Record<string, string>;
+  workflows: Record<string, SkillWorkflowStep[]>;
+}
+
+export class SkillManager {
+  private skills: Map<string, SkillPack> = new Map();
+  private loaded = false;
+
+  constructor(private skillsDir: string = path.join(process.cwd(), 'browser', 'skills')) {}
+
+  async loadSkills(): Promise<void> {
+    if (this.loaded) return;
+    const exists = await this.exists(this.skillsDir);
+    if (!exists) {
+      this.loaded = true;
+      return;
+    }
+
+    const entries = await fs.readdir(this.skillsDir);
+    for (const entry of entries) {
+      if (!entry.endsWith('.skill.json')) continue;
+      const raw = await fs.readFile(path.join(this.skillsDir, entry), 'utf8');
+      const skill = JSON.parse(raw) as SkillPack;
+      this.skills.set(skill.id, skill);
+    }
+
+    this.loaded = true;
+  }
+
+  async getActiveSkillForPage(pageContext: PageContext): Promise<SkillPack | null> {
+    await this.loadSkills();
+
+    if (pageContext.snapshotId && pageContext.virtualDomain) {
+      const skill = this.matchSkillByDomain(pageContext.virtualDomain);
+      if (skill) return skill;
+    }
+
+    const hintSkill = this.getSkillByHint(pageContext.skillHint);
+    if (hintSkill) {
+      return hintSkill;
+    }
+
+    if (pageContext.virtualDomain) {
+      const skill = this.matchSkillByDomain(pageContext.virtualDomain);
+      if (skill) return skill;
+    }
+
+    const liveDomain = this.safeDomainFromUrl(pageContext.url);
+    if (liveDomain) {
+      const skill = this.matchSkillByDomain(liveDomain);
+      if (skill) return skill;
+    }
+
+    return null;
+  }
+
+  getSkillById(id: string): SkillPack | null {
+    return this.skills.get(id) ?? null;
+  }
+
+  getSkillByHint(hint?: string | null): SkillPack | null {
+    if (!hint) return null;
+    const normalized = hint.toLowerCase();
+    return this.skills.get(normalized) ?? null;
+  }
+
+  private matchSkillByDomain(domain: string): SkillPack | null {
+    for (const skill of this.skills.values()) {
+      if (skill.domain.some(d => domain === d || domain.endsWith(d))) {
+        return skill;
+      }
+    }
+    return null;
+  }
+
+  private safeDomainFromUrl(url: string): string | null {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return null;
+    }
+  }
+
+  private async exists(target: string): Promise<boolean> {
+    try {
+      await fs.access(target);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const skillManager = new SkillManager();

--- a/services/skillWorkflowExecutor.ts
+++ b/services/skillWorkflowExecutor.ts
@@ -1,0 +1,124 @@
+import { CheerioAPI, load } from 'cheerio';
+import { SkillPack, SkillWorkflowStep } from './skillManager';
+import { PageContext } from './vaultProtocol';
+
+export interface WorkflowExecutionResult {
+  success: boolean;
+  logs: string[];
+  extractedText?: string[];
+  skippedNavigations: number;
+}
+
+export class SkillWorkflowExecutor {
+  async runWorkflow(
+    skill: SkillPack,
+    workflowName: string,
+    options: {
+      html?: string;
+      pageContext: PageContext;
+      navigate?: (url: string) => Promise<void>;
+      click?: (selector: string) => Promise<void>;
+      waitForSelector?: (selector: string) => Promise<void>;
+    }
+  ): Promise<WorkflowExecutionResult> {
+    const steps = skill.workflows[workflowName];
+    if (!steps) {
+      return { success: false, logs: [`Workflow ${workflowName} not found`], skippedNavigations: 0 };
+    }
+
+    const logs: string[] = [];
+    const extractedText: string[] = [];
+    let skippedNavigations = 0;
+    const $ = options.html ? load(options.html) : null;
+
+    for (const step of steps) {
+      const result = await this.executeStep(step, {
+        ...options,
+        $, // include parsed DOM for snapshot mode
+        logs,
+        extractedText,
+      });
+
+      skippedNavigations += result.skippedNavigations ?? 0;
+      if (!result.success) {
+        logs.push(`Step failed: ${step.action} ${step.selector ?? step.url ?? ''}`.trim());
+        return { success: false, logs, extractedText, skippedNavigations };
+      }
+    }
+
+    return { success: true, logs, extractedText, skippedNavigations };
+  }
+
+  private async executeStep(
+    step: SkillWorkflowStep,
+    context: {
+      pageContext: PageContext;
+      navigate?: (url: string) => Promise<void>;
+      click?: (selector: string) => Promise<void>;
+      waitForSelector?: (selector: string) => Promise<void>;
+      $: CheerioAPI | null;
+      logs: string[];
+      extractedText: string[];
+    }
+  ): Promise<{ success: boolean; skippedNavigations?: number }> {
+    const { logs, pageContext } = context;
+    const isSnapshot = pageContext.isVaultSnapshot;
+
+    switch (step.action) {
+      case 'goto': {
+        if (isSnapshot) {
+          logs.push('Skipping navigation: snapshot mode.');
+          return { success: true, skippedNavigations: 1 };
+        }
+        if (context.navigate && step.url) {
+          await context.navigate(step.url);
+          logs.push(`Navigated to ${step.url}`);
+          return { success: true };
+        }
+        logs.push('Navigation step missing URL or navigate callback.');
+        return { success: false };
+      }
+      case 'waitForSelector': {
+        if (isSnapshot && context.$ && step.selector) {
+          const exists = context.$(step.selector).length > 0;
+          logs.push(exists ? `Found selector ${step.selector}` : `Selector ${step.selector} missing`);
+          return { success: exists };
+        }
+        if (context.waitForSelector && step.selector) {
+          await context.waitForSelector(step.selector);
+          logs.push(`Waited for selector ${step.selector}`);
+          return { success: true };
+        }
+        return { success: false };
+      }
+      case 'click': {
+        if (isSnapshot && context.$ && step.selector) {
+          const exists = context.$(step.selector).length > 0;
+          logs.push(exists ? `Pretend click on ${step.selector} (snapshot).` : `Cannot click missing ${step.selector}`);
+          return { success: exists };
+        }
+        if (context.click && step.selector) {
+          await context.click(step.selector);
+          logs.push(`Clicked ${step.selector}`);
+          return { success: true };
+        }
+        return { success: false };
+      }
+      case 'extractText': {
+        if (context.$ && step.selector) {
+          const text = context.$(step.selector).text().trim();
+          context.extractedText.push(text);
+          logs.push(`Extracted text from ${step.selector}: ${text}`);
+          return { success: true };
+        }
+        logs.push('Missing selector or DOM for extractText.');
+        return { success: false };
+      }
+      default:
+        logs.push(`Unknown action ${step.action}`);
+        return { success: false };
+    }
+  }
+}
+
+export const skillWorkflowExecutor = new SkillWorkflowExecutor();

--- a/services/vaultProtocol.ts
+++ b/services/vaultProtocol.ts
@@ -1,0 +1,84 @@
+import path from 'path';
+import { vaultService, VaultSnapshotMeta } from './vaultService';
+
+export interface PageContext {
+  url: string;
+  virtualDomain?: string;
+  snapshotId?: string;
+  skillHint?: string;
+  isVaultSnapshot: boolean;
+}
+
+export class VaultProtocol {
+  private readonly vaultPrefix = 'vault://page/';
+
+  async resolve(url: string): Promise<{ html?: string; meta?: VaultSnapshotMeta; pageContext: PageContext }> {
+    if (!this.isVaultPage(url)) {
+      return {
+        pageContext: {
+          url,
+          isVaultSnapshot: false,
+        },
+      };
+    }
+
+    const snapshotId = this.extractSnapshotId(url);
+    const snapshot = snapshotId ? await vaultService.getSnapshotById(snapshotId) : null;
+
+    if (!snapshot || !snapshot.meta) {
+      return {
+        pageContext: {
+          url,
+          snapshotId,
+          isVaultSnapshot: true,
+        },
+      };
+    }
+
+    return {
+      html: snapshot.html,
+      meta: snapshot.meta,
+      pageContext: this.buildPageContext(url, snapshot.meta),
+    };
+  }
+
+  isVaultPage(url: string): boolean {
+    return url.startsWith(this.vaultPrefix);
+  }
+
+  extractSnapshotId(url: string): string | null {
+    if (!this.isVaultPage(url)) return null;
+    return url.replace(this.vaultPrefix, '').split('?')[0];
+  }
+
+  buildPageContext(url: string, meta: VaultSnapshotMeta): PageContext {
+    return {
+      url,
+      virtualDomain: meta.domain,
+      snapshotId: meta.id,
+      skillHint: meta.skillHint,
+      isVaultSnapshot: true,
+    };
+  }
+
+  buildLivePageContext(url: string): PageContext {
+    let virtualDomain: string | undefined;
+    try {
+      virtualDomain = new URL(url).hostname;
+    } catch {
+      virtualDomain = undefined;
+    }
+
+    return {
+      url,
+      virtualDomain,
+      isVaultSnapshot: false,
+    };
+  }
+
+  metaPath(id: string): string {
+    return path.join(process.cwd(), 'PalmVault', 'meta', `${id}.json`);
+  }
+}
+
+export const vaultProtocol = new VaultProtocol();

--- a/services/vaultService.ts
+++ b/services/vaultService.ts
@@ -1,0 +1,188 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+export interface VaultSnapshotMeta {
+  id: string;
+  url: string;
+  domain: string;
+  title?: string;
+  tags?: string[];
+  createdAt: string;
+  missionId?: string;
+  skillHint?: string;
+}
+
+export interface VaultIndexEntry {
+  id: string;
+  title?: string;
+  domain: string;
+  tags?: string[];
+  createdAt: string;
+  skillHint?: string;
+}
+
+export interface SaveSnapshotPayload {
+  url: string;
+  html: string;
+  markdown?: string;
+  title?: string;
+  tags?: string[];
+  missionId?: string;
+  skillHint?: string;
+}
+
+export class VaultService {
+  private vaultRoot: string;
+  private pagesDir: string;
+  private markdownDir: string;
+  private metaDir: string;
+  private indexPath: string;
+
+  constructor(rootDir: string = path.join(process.cwd(), 'PalmVault')) {
+    this.vaultRoot = rootDir;
+    this.pagesDir = path.join(this.vaultRoot, 'pages');
+    this.markdownDir = path.join(this.vaultRoot, 'markdown');
+    this.metaDir = path.join(this.vaultRoot, 'meta');
+    this.indexPath = path.join(this.vaultRoot, 'index.json');
+  }
+
+  async saveSnapshot(payload: SaveSnapshotPayload): Promise<VaultSnapshotMeta> {
+    await this.ensureStructure();
+
+    const id = randomUUID();
+    const domain = this.extractDomain(payload.url);
+    const skillHint = payload.skillHint ?? this.deriveSkillHint(domain);
+    const createdAt = new Date().toISOString();
+    const baseTags = payload.tags ?? [];
+    const tags = this.enrichTags(baseTags, domain, skillHint);
+
+    const meta: VaultSnapshotMeta = {
+      id,
+      url: payload.url,
+      domain,
+      title: payload.title,
+      tags,
+      createdAt,
+      missionId: payload.missionId,
+      skillHint,
+    };
+
+    await fs.writeFile(path.join(this.pagesDir, `${id}.html`), payload.html, 'utf8');
+    if (payload.markdown) {
+      await fs.writeFile(path.join(this.markdownDir, `${id}.md`), payload.markdown, 'utf8');
+    }
+    await fs.writeFile(path.join(this.metaDir, `${id}.json`), JSON.stringify(meta, null, 2), 'utf8');
+    await this.updateIndex(meta);
+
+    return meta;
+  }
+
+  async getSnapshotMeta(id: string): Promise<VaultSnapshotMeta | null> {
+    try {
+      const raw = await fs.readFile(path.join(this.metaDir, `${id}.json`), 'utf8');
+      return JSON.parse(raw) as VaultSnapshotMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  async getSnapshotById(id: string): Promise<{ html?: string; markdown?: string; meta?: VaultSnapshotMeta } | null> {
+    const meta = await this.getSnapshotMeta(id);
+    if (!meta) return null;
+
+    const [html, markdown] = await Promise.all([
+      this.readOptional(path.join(this.pagesDir, `${id}.html`)),
+      this.readOptional(path.join(this.markdownDir, `${id}.md`)),
+    ]);
+
+    return { html: html ?? undefined, markdown: markdown ?? undefined, meta };
+  }
+
+  async listSnapshots(): Promise<VaultIndexEntry[]> {
+    const exists = await this.exists(this.indexPath);
+    if (!exists) return [];
+
+    const raw = await fs.readFile(this.indexPath, 'utf8');
+    return JSON.parse(raw) as VaultIndexEntry[];
+  }
+
+  openSnapshot(id: string): string {
+    return `vault://page/${id}`;
+  }
+
+  private async ensureStructure(): Promise<void> {
+    await fs.mkdir(this.vaultRoot, { recursive: true });
+    await Promise.all([
+      fs.mkdir(this.pagesDir, { recursive: true }),
+      fs.mkdir(this.markdownDir, { recursive: true }),
+      fs.mkdir(this.metaDir, { recursive: true }),
+    ]);
+
+    const exists = await this.exists(this.indexPath);
+    if (!exists) {
+      await fs.writeFile(this.indexPath, '[]', 'utf8');
+    }
+  }
+
+  private extractDomain(url: string): string {
+    try {
+      const parsed = new URL(url);
+      return parsed.host;
+    } catch {
+      return url;
+    }
+  }
+
+  private deriveSkillHint(domain: string): string | undefined {
+    const normalized = domain.toLowerCase();
+    if (normalized.includes('youtube.com')) return 'youtube';
+    if (normalized.includes('tiktok.com')) return 'tiktok';
+    if (normalized.includes('supabase.io')) return 'supabase';
+    return undefined;
+  }
+
+  private async updateIndex(meta: VaultSnapshotMeta): Promise<void> {
+    const index = await this.listSnapshots();
+    const entry: VaultIndexEntry = {
+      id: meta.id,
+      title: meta.title ?? meta.url,
+      domain: meta.domain,
+      tags: meta.tags,
+      createdAt: meta.createdAt,
+      skillHint: meta.skillHint,
+    };
+
+    const filtered = index.filter(item => item.id !== meta.id);
+    filtered.push(entry);
+    await fs.writeFile(this.indexPath, JSON.stringify(filtered, null, 2), 'utf8');
+  }
+
+  private enrichTags(tags: string[], domain: string, skillHint?: string): string[] {
+    const set = new Set(tags);
+    set.add(`source:${domain}`);
+    if (skillHint) {
+      set.add(`skill:${skillHint}`);
+    }
+    return Array.from(set);
+  }
+
+  private async exists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readOptional(filePath: string): Promise<string | null> {
+    try {
+      return await fs.readFile(filePath, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const vaultService = new VaultService();

--- a/tools/qa/vault-skills-smoke.ts
+++ b/tools/qa/vault-skills-smoke.ts
@@ -1,0 +1,69 @@
+import { vaultService } from '../../services/vaultService';
+import { vaultProtocol } from '../../services/vaultProtocol';
+import { skillManager } from '../../services/skillManager';
+import { skillWorkflowExecutor } from '../../services/skillWorkflowExecutor';
+
+async function main() {
+  const sampleHtml = `
+    <html>
+      <head><title>YouTube Studio Snapshot</title></head>
+      <body>
+        <div id="analytics-button">Analytics</div>
+        <section id="analytics-overview">Views in the last 7 days: 1,234</section>
+      </body>
+    </html>
+  `;
+
+  const meta = await vaultService.saveSnapshot({
+    url: 'https://studio.youtube.com/channel/demo/analytics',
+    html: sampleHtml,
+    markdown: '# YouTube Analytics Snapshot\nSaved for offline skill testing.',
+    title: 'YouTube Studio Analytics Snapshot',
+  });
+
+  const snapshotUrl = vaultService.openSnapshot(meta.id);
+  const resolved = await vaultProtocol.resolve(snapshotUrl);
+  const pageContext = { ...resolved.pageContext, skillHint: meta.skillHint };
+
+  console.log('Snapshot saved at', snapshotUrl);
+  console.log('Virtual domain detected:', pageContext.virtualDomain);
+
+  if (pageContext.virtualDomain !== 'studio.youtube.com') {
+    console.error('Virtual domain mismatch, expected studio.youtube.com');
+    process.exit(1);
+  }
+
+  const skill = await skillManager.getActiveSkillForPage(pageContext);
+  if (!skill) {
+    console.error('No skill pack loaded for the virtual domain.');
+    process.exit(1);
+  }
+
+  console.log('Loaded skill:', skill.id);
+
+  const result = await skillWorkflowExecutor.runWorkflow(skill, 'openAnalytics', {
+    html: resolved.html,
+    pageContext,
+  });
+
+  console.log('Workflow logs:');
+  for (const log of result.logs) {
+    console.log(' -', log);
+  }
+
+  if (result.extractedText?.length) {
+    console.log('Extracted:', result.extractedText.join(' | '));
+  }
+
+  if (result.success) {
+    console.log('Vault skill smoke test passed.');
+  } else {
+    console.error('Vault skill smoke test failed.');
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Vault skills smoke test crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add vault snapshot metadata handling with domain and skill hints plus vault:// protocol context
- introduce skill management, snapshot-aware workflow execution, and plugin helpers for virtual domains
- document vault-skill integration and provide a YouTube skill pack with a vault smoke test

## Testing
- npm run qa:vault-skills

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df23eecdc832492f07a3421786d29)