### PR TITLE
Add Browser Forge scaffolding and QA hooks

### DIFF
--- a/dashboard/app/dev/forge/page.tsx
+++ b/dashboard/app/dev/forge/page.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { mineForgeCandidates } from '../../../../src/browser/forge/forgeMiner';
+import { proposeSkillChanges } from '../../../../src/browser/forge/forgeSynthesizer';
+import { ForgeCandidate, ForgeChangeProposal } from '../../../../src/browser/forge/forgeTypes';
+
+interface ProposalState {
+  [candidateId: string]: ForgeChangeProposal | undefined;
+}
+
+export default function ForgePage() {
+  const [candidates, setCandidates] = useState<ForgeCandidate[]>([]);
+  const [proposals, setProposals] = useState<ProposalState>({});
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    mineForgeCandidates().then(setCandidates).catch(console.error);
+  }, []);
+
+  const totals = useMemo(() => ({
+    selectors: candidates.reduce((sum, c) => sum + c.selectors.length, 0),
+    workflows: candidates.reduce((sum, c) => sum + c.workflows.length, 0),
+  }), [candidates]);
+
+  const handleGenerateProposal = async (candidate: ForgeCandidate) => {
+    setLoadingId(candidate.id);
+    try {
+      const proposal = await proposeSkillChanges(candidate);
+      setProposals(prev => ({ ...prev, [candidate.id]: proposal }));
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'Inter, sans-serif' }}>
+      <h1>Browser Forge</h1>
+      <p>Automatically mined skill candidates from shadow mode, sentinel, and orchestrator signals.</p>
+
+      <div style={{ margin: '1rem 0', padding: '1rem', border: '1px solid #ddd', borderRadius: 8 }}>
+        <strong>Aggregate</strong>
+        <div>Total candidates: {candidates.length}</div>
+        <div>Total selectors: {totals.selectors}</div>
+        <div>Total workflows: {totals.workflows}</div>
+      </div>
+
+      <div style={{ display: 'grid', gap: '1rem' }}>
+        {candidates.map(candidate => (
+          <div key={candidate.id} style={{ border: '1px solid #ccc', borderRadius: 8, padding: '1rem' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <h3 style={{ margin: 0 }}>{candidate.virtualDomain || candidate.id}</h3>
+                <small>Status: {candidate.status} | Source: {candidate.source}</small>
+                {candidate.notes ? <div style={{ marginTop: 4 }}>Notes: {candidate.notes}</div> : null}
+              </div>
+              <button onClick={() => handleGenerateProposal(candidate)} disabled={loadingId === candidate.id}>
+                {loadingId === candidate.id ? 'Generating…' : 'Generate Proposal'}
+              </button>
+            </div>
+
+            <div style={{ marginTop: '0.5rem' }}>
+              <strong>Selectors</strong>
+              <ul>
+                {candidate.selectors.map(selector => (
+                  <li key={selector.selector}>
+                    {selector.selector} (used {selector.usageCount}x, success {Math.round(selector.successRate * 100)}%)
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <strong>Workflows</strong>
+              <ul>
+                {candidate.workflows.map(workflow => (
+                  <li key={workflow.name}>
+                    {workflow.name} — {workflow.description} (success {Math.round(workflow.successRate * 100)}%)
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {proposals[candidate.id] ? (
+              <div style={{ marginTop: '0.5rem', background: '#f6f8fb', padding: '0.75rem', borderRadius: 6 }}>
+                <strong>Proposal</strong>
+                <div>{proposals[candidate.id]?.summary}</div>
+                <div>Selectors proposed: {proposals[candidate.id]?.selectorChanges.length}</div>
+                <div>Workflows proposed: {proposals[candidate.id]?.workflowChanges.length}</div>
+                <div style={{ fontSize: 12, color: '#555', marginTop: 4 }}>
+                  Apply via forge.apply_changes tool from the orchestrator console.
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/dev/browser-forge.md
+++ b/docs/dev/browser-forge.md
@@ -1,0 +1,37 @@
+# Browser Forge
+
+Browser Forge is the learning loop that turns shadow mode recordings, Sentinel alerts, and orchestrated workflows into new or improved skill packs. It mines candidate patterns, proposes changes, and lets you preview or apply those updates safely.
+
+## Lifecycle
+
+1. **Mine candidates**: Aggregate shadow flows, Sentinel warnings, and repeated task successes to identify selectors and workflows worth turning into skills.
+2. **Propose changes**: Use the synthesizer to generate selector and workflow patches that match the skill pack format.
+3. **Review**: Inspect candidates and proposals in the Forge dashboard (`/dev/forge`).
+4. **Apply**: Preview or apply proposals to skill pack files under `src/browser/skills/`.
+5. **Validate**: Use vault snapshots to sanity-check selectors and workflows before shipping.
+
+## Key modules
+
+- `src/browser/forge/forgeMiner.ts`: Gathers raw candidates from shadow data and Sentinel-style events.
+- `src/browser/forge/forgeSynthesizer.ts`: Generates human-readable proposals for selectors and workflows.
+- `src/browser/forge/forgeApplier.ts`: Creates diffs and writes updated `.skill.json` files in safe mode.
+- `services/automation/forgeMission.ts`: Mission wrapper for orchestrator-style flows with optional auto-apply.
+- `services/enhancedToolService.ts`: Exposes forge actions as native tools (`forge.*`) for MCP callers.
+- `dashboard/app/dev/forge/page.tsx`: Lightweight review UI to browse candidates and trigger proposals.
+
+## Running a Forge mission
+
+```bash
+npm run qa:forge
+```
+
+This smoke test mines a mock candidate, synthesizes a proposal, shows a diff, and writes the resulting skill pack.
+
+For programmatic control, use the forge tools:
+- `forge.mine_candidates` — list candidates (optional domain filter)
+- `forge.propose_changes` — generate a proposal for a candidate
+- `forge.apply_changes` — preview or apply a proposal
+
+## Snapshot validation
+
+Forge applier is snapshot-aware: skill updates are written to disk in `apply` mode, and preview mode returns a diff. Hook snapshot validation into `forgeApplier` to assert selectors exist in `vault://` snapshots before committing.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean:git": "git clean -fd",
     "preview": "vite preview",
     "electron": "tsx electron/main.ts",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "qa:forge": "tsx tools/qa/forge-smoke.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/services/automation/forgeMission.ts
+++ b/services/automation/forgeMission.ts
@@ -1,0 +1,36 @@
+import { mineForgeCandidates } from '../../src/browser/forge/forgeMiner';
+import { proposeSkillChanges } from '../../src/browser/forge/forgeSynthesizer';
+import { applyForgeProposal } from '../../src/browser/forge/forgeApplier';
+
+export type ForgeMissionMode = 'preview' | 'apply';
+
+export interface ForgeMissionInput {
+  domain?: string;
+  skillId?: string;
+  autoApply?: boolean;
+}
+
+export interface ForgeMissionResult {
+  proposals: Array<{ candidateId: string; summary: string; preview?: string }>;
+}
+
+export async function runForgeMission(input: ForgeMissionInput = {}, mode: ForgeMissionMode = 'preview'): Promise<ForgeMissionResult> {
+  const candidates = await mineForgeCandidates();
+  const filtered = input.domain ? candidates.filter(candidate => candidate.virtualDomain?.includes(input.domain)) : candidates;
+
+  const proposals = [] as ForgeMissionResult['proposals'];
+  for (const candidate of filtered) {
+    const proposal = await proposeSkillChanges(candidate);
+    if (mode === 'apply' || input.autoApply) {
+      const result = await applyForgeProposal(proposal, 'apply');
+      proposals.push({ candidateId: candidate.id, summary: proposal.summary, preview: result.newSkillFilePath });
+    } else {
+      const preview = await applyForgeProposal(proposal, 'preview');
+      proposals.push({ candidateId: candidate.id, summary: proposal.summary, preview: preview.previewDiff });
+    }
+  }
+
+  return { proposals };
+}
+
+export const ForgeMissionType = 'system.forge_skills';

--- a/services/automation/index.ts
+++ b/services/automation/index.ts
@@ -18,6 +18,7 @@ export * from './policy';
 export * from './reflection';
 export * from './memory';
 export * from './telemetry';
+export * from './forgeMission';
 
 // Examples and utilities
 export * from './examples';

--- a/services/mcp/toolRegistry.ts
+++ b/services/mcp/toolRegistry.ts
@@ -101,6 +101,7 @@ export class MCPToolRegistry {
       'browser': ['navigate_to_url', 'click_element', 'fill_form_element', 'read_page_content', 'take_screenshot'],
       'search': ['google_search'],
       'automation': ['execute_javascript', 'create_plan'],
+      'forge': ['forge.mine_candidates', 'forge.propose_changes', 'forge.apply_changes'],
       'analysis': ['summarize_current_page'],
       'completion': ['task_completed'],
       'scraping': ['scrape_page', 'extract_data', 'parse_html'],

--- a/src/browser/forge/forgeApplier.ts
+++ b/src/browser/forge/forgeApplier.ts
@@ -1,0 +1,114 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getForgeCandidate, updateForgeCandidate } from './forgeState';
+import { ForgeChangeProposal } from './forgeTypes';
+
+const SKILL_DIR = path.join(process.cwd(), 'src', 'browser', 'skills');
+
+interface SkillPack {
+  id: string;
+  domains?: string[];
+  selectors: any[];
+  workflows: any[];
+  description?: string;
+  metadata?: Record<string, any>;
+}
+
+async function ensureSkillDir(): Promise<void> {
+  await fs.mkdir(SKILL_DIR, { recursive: true });
+}
+
+async function loadSkillPack(skillId: string): Promise<SkillPack | null> {
+  const filePath = path.join(SKILL_DIR, `${skillId}.skill.json`);
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content) as SkillPack;
+  } catch (error) {
+    return null;
+  }
+}
+
+function mergeSkill(existing: SkillPack | null, proposal: ForgeChangeProposal): SkillPack {
+  const base: SkillPack = existing || {
+    id: proposal.targetSkillId || proposal.newSkillId || `forge-${Date.now()}`,
+    selectors: [],
+    workflows: [],
+    metadata: {},
+    description: proposal.summary,
+  };
+
+  const selectors = [...base.selectors];
+  for (const change of proposal.selectorChanges) {
+    const index = selectors.findIndex(sel => sel.name === change.name || sel.selector === change.selector);
+    if (index >= 0) {
+      selectors[index] = { ...selectors[index], ...change };
+    } else {
+      selectors.push(change);
+    }
+  }
+
+  const workflows = [...base.workflows];
+  for (const change of proposal.workflowChanges) {
+    const index = workflows.findIndex(wf => wf.name === change.name);
+    if (index >= 0) {
+      workflows[index] = { ...workflows[index], ...change };
+    } else {
+      workflows.push(change);
+    }
+  }
+
+  return {
+    ...base,
+    selectors,
+    workflows,
+    description: proposal.summary,
+    metadata: {
+      ...base.metadata,
+      generatedBy: 'browser-forge',
+      generatedAt: new Date().toISOString(),
+    },
+  };
+}
+
+function createDiff(current: SkillPack | null, updated: SkillPack): string {
+  const currentString = JSON.stringify(current || {}, null, 2);
+  const updatedString = JSON.stringify(updated, null, 2);
+  const currentLines = currentString.split('\n').map(line => `- ${line}`);
+  const updatedLines = updatedString.split('\n').map(line => `+ ${line}`);
+  return ['--- current', '+++ proposed', ...currentLines, ...updatedLines].join('\n');
+}
+
+async function writeSkillPack(updated: SkillPack): Promise<string> {
+  await ensureSkillDir();
+  const filePath = path.join(SKILL_DIR, `${updated.id}.skill.json`);
+  await fs.writeFile(filePath, JSON.stringify(updated, null, 2), 'utf-8');
+  return filePath;
+}
+
+export async function applyForgeProposal(
+  proposal: ForgeChangeProposal,
+  mode: 'preview' | 'apply'
+): Promise<{ previewDiff?: string; applied: boolean; newSkillFilePath?: string }>
+{
+  await ensureSkillDir();
+  const existing = proposal.targetSkillId ? await loadSkillPack(proposal.targetSkillId) : null;
+  const updated = mergeSkill(existing, proposal);
+
+  if (mode === 'preview') {
+    return {
+      previewDiff: createDiff(existing, updated),
+      applied: false,
+    };
+  }
+
+  const newSkillFilePath = await writeSkillPack(updated);
+  const candidate = proposal.targetSkillId ? getForgeCandidate(proposal.targetSkillId) : undefined;
+  if (candidate) {
+    updateForgeCandidate({ ...candidate, status: 'merged' });
+  }
+
+  return {
+    applied: true,
+    newSkillFilePath,
+  };
+}

--- a/src/browser/forge/forgeMiner.ts
+++ b/src/browser/forge/forgeMiner.ts
@@ -1,0 +1,136 @@
+import { ForgeCandidate } from './forgeTypes';
+import { setForgeCandidates } from './forgeState';
+
+interface ShadowFlow {
+  id: string;
+  domain: string;
+  steps: Array<{ action: string; target?: string; value?: string; success: boolean }>;
+  selectorsUsed: string[];
+  success: boolean;
+  urlSample?: string;
+}
+
+interface SentinelEvent {
+  id: string;
+  domain: string;
+  type: 'missing-selector' | 'skill-pack-mismatch' | 'popup-detected';
+  selector?: string;
+  recovered?: boolean;
+  timestamp: string;
+}
+
+const mockShadowFlows: ShadowFlow[] = [
+  {
+    id: 'shadow-1',
+    domain: 'studio.youtube.com',
+    success: true,
+    selectorsUsed: ['#menu-button', 'button#create'],
+    urlSample: 'https://studio.youtube.com/channel/analytics',
+    steps: [
+      { action: 'goto', target: 'https://studio.youtube.com', success: true },
+      { action: 'click', target: '#menu-button', success: true },
+      { action: 'click', target: 'button#create', success: true },
+    ],
+  },
+  {
+    id: 'shadow-2',
+    domain: 'studio.youtube.com',
+    success: false,
+    selectorsUsed: ['#menu-button', 'button#create'],
+    urlSample: 'https://studio.youtube.com/channel/analytics',
+    steps: [
+      { action: 'goto', target: 'https://studio.youtube.com', success: true },
+      { action: 'click', target: '#menu-button', success: false },
+    ],
+  },
+  {
+    id: 'shadow-3',
+    domain: 'ads.tiktok.com',
+    success: true,
+    selectorsUsed: ['.nav-link.analytics', 'button.export'],
+    urlSample: 'https://ads.tiktok.com/analytics',
+    steps: [
+      { action: 'goto', target: 'https://ads.tiktok.com', success: true },
+      { action: 'click', target: '.nav-link.analytics', success: true },
+      { action: 'click', target: 'button.export', success: true },
+    ],
+  },
+];
+
+const mockSentinelEvents: SentinelEvent[] = [
+  {
+    id: 'sentinel-1',
+    domain: 'studio.youtube.com',
+    type: 'missing-selector',
+    selector: '#menu-button',
+    recovered: true,
+    timestamp: new Date().toISOString(),
+  },
+  {
+    id: 'sentinel-2',
+    domain: 'ads.tiktok.com',
+    type: 'popup-detected',
+    timestamp: new Date().toISOString(),
+  },
+];
+
+function buildSelectorStats(flows: ShadowFlow[]): ForgeCandidate['selectors'] {
+  const stats = new Map<string, { usageCount: number; successes: number; lastSeenAt: string }>();
+
+  for (const flow of flows) {
+    for (const selector of flow.selectorsUsed) {
+      const current = stats.get(selector) || { usageCount: 0, successes: 0, lastSeenAt: '' };
+      current.usageCount += 1;
+      if (flow.success) current.successes += 1;
+      current.lastSeenAt = new Date().toISOString();
+      stats.set(selector, current);
+    }
+  }
+
+  return Array.from(stats.entries()).map(([selector, detail]) => ({
+    selector,
+    usageCount: detail.usageCount,
+    successRate: detail.usageCount === 0 ? 0 : Math.round((detail.successes / detail.usageCount) * 100) / 100,
+    lastSeenAt: detail.lastSeenAt,
+  }));
+}
+
+function buildWorkflows(flows: ShadowFlow[]): ForgeCandidate['workflows'] {
+  return flows.map(flow => ({
+    name: `${flow.domain}-workflow-${flow.id}`,
+    description: `Learned from shadow flow ${flow.id}`,
+    steps: flow.steps,
+    successRate: flow.success ? 1 : 0,
+    failurePatterns: flow.success ? [] : ['shadow divergence'],
+  }));
+}
+
+export async function mineForgeCandidates(): Promise<ForgeCandidate[]> {
+  const flowsByDomain = mockShadowFlows.reduce<Record<string, ShadowFlow[]>>((acc, flow) => {
+    acc[flow.domain] = acc[flow.domain] || [];
+    acc[flow.domain].push(flow);
+    return acc;
+  }, {});
+
+  const candidates: ForgeCandidate[] = Object.entries(flowsByDomain).map(([domain, flows]) => {
+    const selectors = buildSelectorStats(flows);
+    const workflows = buildWorkflows(flows);
+    const sentinelNotes = mockSentinelEvents.filter(event => event.domain === domain);
+
+    return {
+      id: `forge-${domain}`,
+      source: 'shadow',
+      createdAt: new Date().toISOString(),
+      virtualDomain: domain,
+      urlSample: flows[0]?.urlSample,
+      selectors,
+      workflows,
+      targetSkillId: domain.includes('youtube') ? 'youtube' : undefined,
+      status: 'candidate',
+      notes: sentinelNotes.map(event => `${event.type}${event.selector ? `:${event.selector}` : ''}`).join(', '),
+    };
+  });
+
+  setForgeCandidates(candidates);
+  return candidates;
+}

--- a/src/browser/forge/forgeState.ts
+++ b/src/browser/forge/forgeState.ts
@@ -1,0 +1,29 @@
+import { ForgeCandidate, ForgeChangeProposal } from './forgeTypes';
+
+const candidateCache = new Map<string, ForgeCandidate>();
+const proposalCache = new Map<string, ForgeChangeProposal>();
+
+export function setForgeCandidates(candidates: ForgeCandidate[]): void {
+  candidateCache.clear();
+  candidates.forEach(candidate => candidateCache.set(candidate.id, candidate));
+}
+
+export function getForgeCandidates(): ForgeCandidate[] {
+  return Array.from(candidateCache.values());
+}
+
+export function getForgeCandidate(id: string): ForgeCandidate | undefined {
+  return candidateCache.get(id);
+}
+
+export function updateForgeCandidate(candidate: ForgeCandidate): void {
+  candidateCache.set(candidate.id, candidate);
+}
+
+export function cacheProposal(candidateId: string, proposal: ForgeChangeProposal): void {
+  proposalCache.set(candidateId, proposal);
+}
+
+export function getCachedProposal(candidateId: string): ForgeChangeProposal | undefined {
+  return proposalCache.get(candidateId);
+}

--- a/src/browser/forge/forgeSynthesizer.ts
+++ b/src/browser/forge/forgeSynthesizer.ts
@@ -1,0 +1,42 @@
+import { cacheProposal } from './forgeState';
+import { ForgeCandidate, ForgeChangeProposal } from './forgeTypes';
+
+function suggestSkillId(candidate: ForgeCandidate): string {
+  if (candidate.targetSkillId) return candidate.targetSkillId;
+  if (candidate.virtualDomain) {
+    return candidate.virtualDomain.replace(/[^a-zA-Z0-9]+/g, '-');
+  }
+  return `forge-skill-${Date.now()}`;
+}
+
+export async function proposeSkillChanges(candidate: ForgeCandidate): Promise<ForgeChangeProposal> {
+  const suggestedSkillId = suggestSkillId(candidate);
+
+  const selectorChanges = candidate.selectors.map(selector => ({
+    action: 'add-or-update',
+    name: selector.name || selector.selector,
+    selector: selector.selector,
+    usageCount: selector.usageCount,
+    successRate: selector.successRate,
+  }));
+
+  const workflowChanges = candidate.workflows.map(workflow => ({
+    action: 'add-or-update',
+    name: workflow.name,
+    description: workflow.description,
+    steps: workflow.steps,
+    successRate: workflow.successRate,
+    failurePatterns: workflow.failurePatterns || [],
+  }));
+
+  const proposal: ForgeChangeProposal = {
+    targetSkillId: candidate.targetSkillId,
+    newSkillId: suggestedSkillId,
+    summary: `Proposed skill updates for ${candidate.virtualDomain || suggestedSkillId}`,
+    selectorChanges,
+    workflowChanges,
+  };
+
+  cacheProposal(candidate.id, proposal);
+  return proposal;
+}

--- a/src/browser/forge/forgeTypes.ts
+++ b/src/browser/forge/forgeTypes.ts
@@ -1,0 +1,38 @@
+export interface ForgeCandidate {
+  id: string;
+  source: 'shadow' | 'sentinel' | 'manual';
+  createdAt: string;
+
+  virtualDomain?: string;
+  urlSample?: string;
+  snapshotId?: string;
+
+  selectors: Array<{
+    name?: string;
+    selector: string;
+    usageCount: number;
+    successRate: number;
+    lastSeenAt: string;
+  }>;
+
+  workflows: Array<{
+    name: string;
+    description: string;
+    steps: any[];
+    successRate: number;
+    failurePatterns?: string[];
+  }>;
+
+  targetSkillId?: string;
+
+  status: 'candidate' | 'approved' | 'rejected' | 'merged';
+  notes?: string;
+}
+
+export interface ForgeChangeProposal {
+  targetSkillId?: string;
+  newSkillId?: string;
+  summary: string;
+  selectorChanges: any[];
+  workflowChanges: any[];
+}

--- a/src/browser/skills/youtube.skill.json
+++ b/src/browser/skills/youtube.skill.json
@@ -1,0 +1,71 @@
+{
+  "id": "youtube",
+  "selectors": [
+    {
+      "action": "add-or-update",
+      "name": "#menu-button",
+      "selector": "#menu-button",
+      "usageCount": 2,
+      "successRate": 0.5
+    },
+    {
+      "action": "add-or-update",
+      "name": "button#create",
+      "selector": "button#create",
+      "usageCount": 2,
+      "successRate": 0.5
+    }
+  ],
+  "workflows": [
+    {
+      "action": "add-or-update",
+      "name": "studio.youtube.com-workflow-shadow-1",
+      "description": "Learned from shadow flow shadow-1",
+      "steps": [
+        {
+          "action": "goto",
+          "target": "https://studio.youtube.com",
+          "success": true
+        },
+        {
+          "action": "click",
+          "target": "#menu-button",
+          "success": true
+        },
+        {
+          "action": "click",
+          "target": "button#create",
+          "success": true
+        }
+      ],
+      "successRate": 1,
+      "failurePatterns": []
+    },
+    {
+      "action": "add-or-update",
+      "name": "studio.youtube.com-workflow-shadow-2",
+      "description": "Learned from shadow flow shadow-2",
+      "steps": [
+        {
+          "action": "goto",
+          "target": "https://studio.youtube.com",
+          "success": true
+        },
+        {
+          "action": "click",
+          "target": "#menu-button",
+          "success": false
+        }
+      ],
+      "successRate": 0,
+      "failurePatterns": [
+        "shadow divergence"
+      ]
+    }
+  ],
+  "metadata": {
+    "generatedBy": "browser-forge",
+    "generatedAt": "2025-12-01T20:08:56.465Z"
+  },
+  "description": "Proposed skill updates for studio.youtube.com"
+}

--- a/tools/qa/forge-smoke.ts
+++ b/tools/qa/forge-smoke.ts
@@ -1,0 +1,27 @@
+import { mineForgeCandidates } from '../../src/browser/forge/forgeMiner';
+import { proposeSkillChanges } from '../../src/browser/forge/forgeSynthesizer';
+import { applyForgeProposal } from '../../src/browser/forge/forgeApplier';
+
+async function run() {
+  console.log('Running Browser Forge smoke test...');
+  const candidates = await mineForgeCandidates();
+  if (!candidates.length) {
+    throw new Error('No forge candidates returned');
+  }
+  console.log(`Found ${candidates.length} candidate(s)`);
+
+  const candidate = candidates[0];
+  const proposal = await proposeSkillChanges(candidate);
+  console.log('Proposal summary:', proposal.summary);
+
+  const preview = await applyForgeProposal(proposal, 'preview');
+  console.log('Preview diff sample:', preview.previewDiff?.split('\n').slice(0, 5).join('\n'));
+
+  const applied = await applyForgeProposal(proposal, 'apply');
+  console.log('Applied skill path:', applied.newSkillFilePath);
+}
+
+run().catch(error => {
+  console.error('Forge smoke test failed:', error);
+  process.exit(1);
+});

--- a/types.ts
+++ b/types.ts
@@ -408,6 +408,39 @@ export const nativeTools: FunctionDeclaration[] = [
             properties: { summary: { type: Type.STRING, description: 'A summary of how the task was completed.' } },
             required: ['summary'],
         },
+    },
+    {
+        name: 'forge.mine_candidates',
+        description: 'Discover forge candidates mined from shadow mode and sentinel data. Optionally filter by domain.',
+        parameters: {
+            type: Type.OBJECT,
+            properties: {
+                domain: { type: Type.STRING, description: 'Optional domain filter such as youtube or tiktok.' },
+            },
+        },
+    },
+    {
+        name: 'forge.propose_changes',
+        description: 'Generate a forge proposal for a given candidate id.',
+        parameters: {
+            type: Type.OBJECT,
+            properties: {
+                candidateId: { type: Type.STRING, description: 'The forge candidate identifier.' },
+            },
+            required: ['candidateId'],
+        },
+    },
+    {
+        name: 'forge.apply_changes',
+        description: 'Preview or apply proposed forge skill changes for a candidate.',
+        parameters: {
+            type: Type.OBJECT,
+            properties: {
+                candidateId: { type: Type.STRING, description: 'The forge candidate identifier.' },
+                mode: { type: Type.STRING, description: "Either 'preview' or 'apply'." },
+            },
+            required: ['candidateId'],
+        },
     }
 ];
 


### PR DESCRIPTION
## Summary
- add Browser Forge data model, miner/synthesizer/applier scaffolding, and generated skill pack storage
- expose forge capabilities through native MCP tools, automation mission helper, and a lightweight Forge dashboard page
- document the Forge lifecycle and add a smoke test script to validate candidate mining through skill application

## Testing
- npm run qa:forge

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df4b359408324a291c5f0dd53c9fc)