### PR TITLE
Add adaptive personal memory engine

### DIFF
--- a/dashboard/app/dev/memory/page.tsx
+++ b/dashboard/app/dev/memory/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { getBehaviorPatterns, getMemoryStore, recommendActions } from '../../../src/memory/memoryEngine';
+import { LearningInsights, Recommendation } from '../../../src/memory/memoryTypes';
+
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+    <div className="bg-gray-900/60 rounded-xl border border-white/10 p-4 shadow-lg">
+        <h2 className="text-lg font-semibold mb-3 text-cyan-300">{title}</h2>
+        {children}
+    </div>
+);
+
+const MemoryPage: React.FC = () => {
+    const [insights, setInsights] = useState<LearningInsights>();
+    const [recommendation, setRecommendation] = useState<Recommendation>();
+
+    useEffect(() => {
+        setInsights(getBehaviorPatterns());
+        setRecommendation(recommendActions('dashboard/dev/memory'));
+    }, []);
+
+    const memory = getMemoryStore();
+
+    const renderList = (items: string[]) => (
+        <ul className="list-disc list-inside space-y-1 text-sm text-gray-200">
+            {items.map((item) => (
+                <li key={item}>{item}</li>
+            ))}
+        </ul>
+    );
+
+    return (
+        <div className="p-6 space-y-6 text-white">
+            <h1 className="text-2xl font-bold text-cyan-200">Adaptive Memory Debugger</h1>
+            <p className="text-sm text-gray-300">Inspect behavior, selectors, and mission history to tune personalization.</p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Section title="Top Domains">{renderList(memory.userBehavior.domains.map((d) => `${d.domain} (${d.visits})`))}</Section>
+                <Section title="Top Workflows">{renderList(memory.userBehavior.workflows.map((w) => `${w.name} — ${Math.round(w.successRate * 100)}%`))}</Section>
+                <Section title="Most Successful Selectors">{renderList(memory.agent.successfulSelectors.map((s) => `${s.selector} (${Math.round(s.confidence * 100)}%)`))}</Section>
+                <Section title="Worst Failing Selectors">{renderList(memory.agent.failedSelectors.map((s) => `${s.selector} (${Math.round(s.confidence * 100)}%)`))}</Section>
+                <Section title="Recommended Improvements">{renderList(insights?.emergingHabits || [])}</Section>
+                <Section title="Memory Graph Snapshot">{renderList(insights?.preferredPanels || [])}</Section>
+                <Section title="Top Mission Sequences">{renderList(memory.missions.shortcuts.map((s) => `${s.name}: ${s.sequence.join(' → ')}`))}</Section>
+                <Section title="Action Recommendations">{renderList(recommendation?.actions || [])}</Section>
+            </div>
+        </div>
+    );
+};
+
+export default MemoryPage;

--- a/docs/dev/adaptive-memory.md
+++ b/docs/dev/adaptive-memory.md
@@ -1,0 +1,48 @@
+# Adaptive Personal Memory Engine
+
+The Adaptive Personal Memory Engine persistently tracks user interactions to personalize the AI Agent Browser. It stores behavior, selector performance, plugin usage, and mission history in an encrypted local data store so the browser, orchestrator, and Sentinel can adapt over time.
+
+## Memory categories
+
+- **UserBehaviorMemory**: domains, skill packs, click patterns, workflows, and time-of-day activity.
+- **AgentMemory**: selector performance including successes, failures, healed selectors, and preferred recovery paths.
+- **BrowserMemory**: plugin affinity, panel usage, pinned sidebars, and shortcut preferences.
+- **ContextualMemory**: keywords, frequently used tags, and content topics to help infer intent.
+- **MissionMemory**: recent missions, completion patterns, and suggested shortcuts or follow-ups.
+
+Each category is described in `src/memory/memoryTypes.ts` and persisted through the memory engine.
+
+## Memory engine
+
+`src/memory/memoryEngine.ts` loads and saves encrypted memory, records incoming events, updates selector confidence, and emits lightweight recommendations. Events cover skill usage, plugin open/close events, orchestrator missions, Sentinel warnings, shadow mode recovery, and vault interactions. Memory is encrypted on disk using AES-256-CTR and sensitive payload fields are sanitized before storage.
+
+## Learning loop
+
+The loop in `src/memory/learningLoop.ts` processes buffered events to update confidence scores, detect habits, and feed insights to Forge, Sentinel, and the mission planner. It can be run on a schedule or invoked directly to flush buffered events.
+
+## Personalization layer
+
+`src/personality/personalization.ts` converts memory signals into UI changes: rearranging toolbars, suggesting plugins to surface or hide, highlighting successful flows, preloading skill packs or vault pages, and offering workflow continuation prompts. Recommendations also inform orchestrator hints.
+
+## Mission-aware planning
+
+`src/orchestrator/memoryAwarePlanner.ts` uses mission history to propose shortcuts, default agents based on past tags, and common follow-up tasks such as post-processing after analytics exports.
+
+## Dashboard UI
+
+`dashboard/app/dev/memory/page.tsx` renders a developer-facing dashboard summarizing top domains, workflows, selector health, mission sequences, and recommended actions. Use it to debug personalization output and tune Forge generation.
+
+## Privacy and safety
+
+`src/memory/privacy.ts` enforces local-only storage, sanitizes sensitive keys, supports private mode, category-level disabling, full memory wipes, and encryption at rest. Update `MEMORY_SECRET` to customize the encryption key.
+
+## Extending the memory system
+
+- Add new event types to `memoryTypes.ts` and handle them in `memoryEngine.ts`.
+- Expand the learning loop with additional detectors and feeds.
+- Extend personalization logic to adjust new UI surfaces.
+- Add more mission planning heuristics based on domain-specific sequences.
+
+## Erase and opt-out options
+
+Developers can call `privacyManager.wipeMemory` to delete stored data, enable private mode to pause collection, or disable specific event categories. Ensure user-facing controls surface these options when wiring the engine into the browser UI.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "clean:git": "git clean -fd",
     "preview": "vite preview",
     "electron": "tsx electron/main.ts",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "qa:memory": "tsx tools/qa/memory-smoke.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.0",

--- a/src/memory/learningLoop.ts
+++ b/src/memory/learningLoop.ts
@@ -1,0 +1,80 @@
+import { clearEventBuffer, getBehaviorPatterns, getEventBuffer, getMemoryStore, saveMemory, updateSkillConfidence } from './memoryEngine';
+import { LearningInsights, MemoryEvent } from './memoryTypes';
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+let intervalId: NodeJS.Timeout | undefined;
+
+const evaluateSelectors = (events: MemoryEvent[]): void => {
+    events.forEach((event) => {
+        if (event.type === 'sentinel_warning' && event.payload.selector) {
+            updateSkillConfidence(event.payload.selector, 'failure');
+        }
+        if (event.type === 'shadow_mode_event' && event.payload.selector) {
+            updateSkillConfidence(event.payload.selector, 'healed');
+        }
+    });
+};
+
+const detectHabits = (): LearningInsights => getBehaviorPatterns();
+
+const feedForge = (insights: LearningInsights): void => {
+    // Hook for Browser Forge generation. In production this would push to a queue or service.
+    if (insights.emergingHabits.length) {
+        console.info('Forge: updating patterns', insights.emergingHabits);
+    }
+};
+
+const feedSentinel = (events: MemoryEvent[]): void => {
+    const warnings = events.filter((event) => event.type === 'sentinel_warning');
+    if (warnings.length) {
+        console.warn('Sentinel: anomalies detected', warnings.length);
+    }
+};
+
+const feedMissionPlanner = (insights: LearningInsights): void => {
+    if (insights.bestPluginCombos.length) {
+        console.info('Mission planner: trend update', insights.bestPluginCombos);
+    }
+};
+
+const updateTrendGraphs = (insights: LearningInsights): void => {
+    const store = getMemoryStore();
+    store.context.contentTopics = store.context.contentTopics.map((topic) => ({
+        ...topic,
+        recencyScore: Math.min(1, topic.recencyScore + 0.05),
+    }));
+    store.browser.panelsUsed = store.browser.panelsUsed.map((panel) => ({
+        ...panel,
+        count: panel.count + (insights.preferredPanels.includes(panel.name) ? 0.5 : 0),
+    }));
+};
+
+export const runLearningCycle = (): LearningInsights => {
+    const bufferedEvents = [...getEventBuffer()];
+    if (!bufferedEvents.length) return getBehaviorPatterns();
+
+    evaluateSelectors(bufferedEvents);
+    const insights = detectHabits();
+    updateTrendGraphs(insights);
+
+    feedForge(insights);
+    feedSentinel(bufferedEvents);
+    feedMissionPlanner(insights);
+
+    saveMemory();
+    clearEventBuffer();
+    return insights;
+};
+
+export const startLearningLoop = (intervalMs: number = DEFAULT_INTERVAL_MS): void => {
+    if (intervalId) return;
+    intervalId = setInterval(() => {
+        runLearningCycle();
+    }, intervalMs);
+};
+
+export const stopLearningLoop = (): void => {
+    if (!intervalId) return;
+    clearInterval(intervalId);
+    intervalId = undefined;
+};

--- a/src/memory/memoryEngine.ts
+++ b/src/memory/memoryEngine.ts
@@ -1,0 +1,301 @@
+import fs from 'fs';
+import path from 'path';
+import {
+    AgentMemory,
+    BrowserMemory,
+    ContextualMemory,
+    LearningInsights,
+    MemoryEvent,
+    MemoryStore,
+    MissionMemory,
+    Recommendation,
+    SelectorStat,
+    UserBehaviorMemory,
+    WorkflowPattern,
+} from './memoryTypes';
+import { privacyManager } from './privacy';
+
+const MEMORY_DIR = path.join(process.cwd(), 'data', 'memory');
+const MEMORY_FILE = path.join(MEMORY_DIR, 'memory.enc');
+
+const defaultUserBehavior = (): UserBehaviorMemory => ({
+    domains: [],
+    skillPacks: [],
+    clickPatterns: [],
+    workflows: [],
+    timeOfDay: [],
+});
+
+const defaultAgentMemory = (): AgentMemory => ({
+    successfulSelectors: [],
+    failedSelectors: [],
+    healedSelectors: [],
+    preferredRecoveryPaths: [],
+});
+
+const defaultBrowserMemory = (): BrowserMemory => ({
+    pluginsLiked: [],
+    panelsUsed: [],
+    sidebarsPinned: [],
+    customShortcuts: [],
+});
+
+const defaultContextualMemory = (): ContextualMemory => ({
+    keywords: [],
+    frequentTags: [],
+    contentTopics: [],
+});
+
+const defaultMissionMemory = (): MissionMemory => ({
+    pastMissions: [],
+    bestPatterns: [],
+    shortcuts: [],
+});
+
+const defaultMemory = (): MemoryStore => ({
+    userBehavior: defaultUserBehavior(),
+    agent: defaultAgentMemory(),
+    browser: defaultBrowserMemory(),
+    context: defaultContextualMemory(),
+    missions: defaultMissionMemory(),
+    updatedAt: new Date().toISOString(),
+});
+
+let memoryStore: MemoryStore = defaultMemory();
+const eventBuffer: MemoryEvent[] = [];
+
+const ensureMemoryDirectory = (): void => {
+    fs.mkdirSync(MEMORY_DIR, { recursive: true });
+};
+
+const readMemoryFromDisk = (): MemoryStore => {
+    ensureMemoryDirectory();
+    if (!fs.existsSync(MEMORY_FILE)) {
+        return defaultMemory();
+    }
+    try {
+        const encrypted = fs.readFileSync(MEMORY_FILE, 'utf8');
+        const decrypted = privacyManager.decrypt(encrypted);
+        const parsed: MemoryStore = JSON.parse(decrypted);
+        return parsed;
+    } catch (error) {
+        console.warn('Failed to load memory, falling back to defaults', error);
+        return defaultMemory();
+    }
+};
+
+const writeMemoryToDisk = (memory: MemoryStore): void => {
+    ensureMemoryDirectory();
+    const payload = JSON.stringify(memory, null, 2);
+    const encrypted = privacyManager.encrypt(payload);
+    fs.writeFileSync(MEMORY_FILE, encrypted, 'utf8');
+};
+
+const updateUsage = (list: { name: string; count: number; lastUsed?: string }[], name: string): void => {
+    const existing = list.find((item) => item.name === name);
+    const now = new Date().toISOString();
+    if (existing) {
+        existing.count += 1;
+        existing.lastUsed = now;
+    } else {
+        list.push({ name, count: 1, lastUsed: now });
+    }
+};
+
+const updateDomainStat = (domains: { domain: string; visits: number; lastVisited?: string; preferredSkillPacks?: string[] }[], domain: string, skillPack?: string): void => {
+    const existing = domains.find((item) => item.domain === domain);
+    const now = new Date().toISOString();
+    if (existing) {
+        existing.visits += 1;
+        existing.lastVisited = now;
+        if (skillPack) {
+            const packs = new Set(existing.preferredSkillPacks || []);
+            packs.add(skillPack);
+            existing.preferredSkillPacks = Array.from(packs);
+        }
+    } else {
+        domains.push({ domain, visits: 1, lastVisited: now, preferredSkillPacks: skillPack ? [skillPack] : [] });
+    }
+};
+
+const updateWorkflowStat = (workflows: WorkflowPattern[], workflowName: string, success?: boolean): void => {
+    const existing = workflows.find((item) => item.name === workflowName);
+    const now = new Date().toISOString();
+    if (existing) {
+        existing.runs += 1;
+        if (typeof success === 'boolean') {
+            const previousSuccesses = Math.round(existing.successRate * (existing.runs - 1));
+            existing.successRate = (previousSuccesses + (success ? 1 : 0)) / existing.runs;
+        }
+        existing.lastRun = now;
+    } else {
+        workflows.push({ name: workflowName, runs: 1, successRate: typeof success === 'boolean' ? (success ? 1 : 0) : 0.5, lastRun: now });
+    }
+};
+
+export const loadMemory = (): MemoryStore => {
+    memoryStore = readMemoryFromDisk();
+    return memoryStore;
+};
+
+export const recordEvent = (event: MemoryEvent): void => {
+    if (!privacyManager.isEventAllowed(event.type)) return;
+    const sanitizedPayload = privacyManager.sanitizePayload(event.payload);
+    const enrichedEvent = { ...event, payload: sanitizedPayload };
+    eventBuffer.push(enrichedEvent);
+
+    switch (event.type) {
+        case 'command_executed':
+            if (event.payload.domain) {
+                updateDomainStat(memoryStore.userBehavior.domains, event.payload.domain, event.payload.skillPack);
+            }
+            updateWorkflowStat(memoryStore.userBehavior.workflows, event.payload.workflow || 'ad-hoc', event.payload.success);
+            break;
+        case 'skill_pack_invoked':
+            if (event.payload.name) {
+                updateUsage(memoryStore.userBehavior.skillPacks, event.payload.name);
+            }
+            if (event.payload.domain) {
+                updateDomainStat(memoryStore.userBehavior.domains, event.payload.domain, event.payload.name);
+            }
+            break;
+        case 'plugin_opened':
+            if (event.payload.plugin) updateUsage(memoryStore.browser.pluginsLiked, event.payload.plugin);
+            break;
+        case 'popup_closed':
+            updateUsage(memoryStore.browser.panelsUsed, event.payload.panel || 'popup');
+            break;
+        case 'sentinel_warning':
+            if (event.payload.selector) {
+                updateSkillConfidence(event.payload.selector, 'failure');
+            }
+            break;
+        case 'shadow_mode_event':
+            if (event.payload.selector && event.payload.recoveredWith) {
+                memoryStore.agent.preferredRecoveryPaths.push({
+                    selector: event.payload.selector,
+                    recoveryPath: event.payload.recoveredWith,
+                    successRate: 1,
+                });
+            }
+            break;
+        case 'orchestrator_mission_start':
+            if (event.payload.missionId) {
+                memoryStore.missions.pastMissions.push({
+                    id: event.payload.missionId,
+                    name: event.payload.name || 'mission',
+                    startedAt: event.timestamp,
+                    success: false,
+                    tags: event.payload.tags || [],
+                });
+            }
+            break;
+        case 'orchestrator_mission_finish':
+            if (event.payload.missionId) {
+                const mission = memoryStore.missions.pastMissions.find((m) => m.id === event.payload.missionId);
+                if (mission) {
+                    mission.finishedAt = event.timestamp;
+                    mission.success = Boolean(event.payload.success);
+                }
+            }
+            break;
+        case 'vault_snapshot_viewed':
+        case 'vault_snapshot_saved':
+            updateUsage(memoryStore.context.frequentTags, event.payload.tag || 'snapshot');
+            break;
+        default:
+            break;
+    }
+    memoryStore.updatedAt = new Date().toISOString();
+};
+
+export const getUserPreferences = () => memoryStore.userBehavior;
+
+export const getBehaviorPatterns = (): LearningInsights => ({
+    emergingHabits: memoryStore.userBehavior.domains
+        .filter((domain) => domain.visits > 2)
+        .map((domain) => `${domain.domain} (${domain.visits})`),
+    weakSelectors: memoryStore.agent.failedSelectors.filter((sel) => sel.confidence < 0.4),
+    strongSelectors: memoryStore.agent.successfulSelectors.filter((sel) => sel.confidence > 0.8),
+    deadWorkflows: memoryStore.userBehavior.workflows.filter((wf) => wf.runs > 3 && wf.successRate < 0.2),
+    preferredPanels: memoryStore.browser.panelsUsed.filter((panel) => panel.count > 3).map((panel) => panel.name),
+    bestPluginCombos: memoryStore.browser.pluginsLiked
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 3)
+        .map((plugin) => [plugin.name]),
+});
+
+export const updateSkillConfidence = (selector: string, outcome: 'success' | 'failure' | 'healed'): void => {
+    const now = new Date().toISOString();
+    const allSelectors: SelectorStat[] = [
+        ...memoryStore.agent.successfulSelectors,
+        ...memoryStore.agent.failedSelectors,
+        ...memoryStore.agent.healedSelectors,
+    ];
+    let target = allSelectors.find((item) => item.selector === selector);
+    if (!target) {
+        target = { selector, confidence: 0.5, lastOutcome: outcome, lastUsed: now };
+        memoryStore.agent.failedSelectors.push(target);
+    }
+
+    const delta = outcome === 'success' ? 0.1 : outcome === 'healed' ? 0.05 : -0.1;
+    target.confidence = Math.min(1, Math.max(0, target.confidence + delta));
+    target.lastOutcome = outcome;
+    target.lastUsed = now;
+
+    if (outcome === 'success') {
+        if (!memoryStore.agent.successfulSelectors.includes(target)) {
+            memoryStore.agent.successfulSelectors.push(target);
+        }
+    } else if (outcome === 'failure') {
+        if (!memoryStore.agent.failedSelectors.includes(target)) {
+            memoryStore.agent.failedSelectors.push(target);
+        }
+    } else if (outcome === 'healed') {
+        if (!memoryStore.agent.healedSelectors.includes(target)) {
+            memoryStore.agent.healedSelectors.push(target);
+        }
+    }
+};
+
+export const recommendActions = (context: string): Recommendation => {
+    const favoriteDomains = memoryStore.userBehavior.domains.sort((a, b) => b.visits - a.visits);
+    const frequentSkills = memoryStore.userBehavior.skillPacks.sort((a, b) => b.count - a.count);
+    const actions: string[] = [];
+
+    if (favoriteDomains.length) {
+        actions.push(`Open ${favoriteDomains[0].domain}`);
+    }
+    if (frequentSkills.length) {
+        actions.push(`Preload skill pack: ${frequentSkills[0].name}`);
+    }
+    if (context) {
+        const topic = memoryStore.context.contentTopics.find((item) => context.includes(item.topic));
+        if (topic) {
+            actions.push(`Highlight ${topic.topic} tools`);
+        }
+    }
+
+    return {
+        actions,
+        confidence: actions.length ? 0.8 : 0.3,
+        reason: actions.length ? 'Derived from recent behavior' : 'Insufficient behavioral data',
+    };
+};
+
+export const getMissionHistory = (): MissionMemory => memoryStore.missions;
+
+export const saveMemory = (): void => {
+    writeMemoryToDisk(memoryStore);
+};
+
+export const getMemoryStore = (): MemoryStore => memoryStore;
+
+export const getEventBuffer = (): MemoryEvent[] => eventBuffer;
+
+export const clearEventBuffer = (): void => {
+    eventBuffer.length = 0;
+};
+
+// Initialize memory on module load
+loadMemory();

--- a/src/memory/memoryTypes.ts
+++ b/src/memory/memoryTypes.ts
@@ -1,0 +1,168 @@
+export type TimeOfDay = 'morning' | 'afternoon' | 'evening' | 'late-night';
+
+export interface DomainStat {
+    domain: string;
+    visits: number;
+    lastVisited?: string;
+    preferredSkillPacks?: string[];
+}
+
+export interface SkillUsage {
+    name: string;
+    count: number;
+    lastUsed?: string;
+}
+
+export interface ClickPattern {
+    element: string;
+    count: number;
+    contexts?: string[];
+}
+
+export interface WorkflowPattern {
+    name: string;
+    successRate: number;
+    runs: number;
+    lastRun?: string;
+}
+
+export interface TimeBehavior {
+    window: TimeOfDay;
+    dominantDomains: string[];
+    activeSkills: string[];
+}
+
+export interface SelectorStat {
+    selector: string;
+    confidence: number;
+    lastOutcome: 'success' | 'failure' | 'healed';
+    lastUsed?: string;
+}
+
+export interface RecoveryPattern {
+    selector: string;
+    recoveryPath: string;
+    successRate: number;
+}
+
+export interface UsageStat {
+    name: string;
+    count: number;
+    lastUsed?: string;
+}
+
+export interface ShortcutPreference {
+    action: string;
+    shortcut: string;
+    frequency: number;
+}
+
+export interface KeywordAssociation {
+    keyword: string;
+    occurrences: number;
+    relatedDomains?: string[];
+}
+
+export interface TopicStat {
+    topic: string;
+    frequency: number;
+    recencyScore: number;
+}
+
+export interface MissionRecord {
+    id: string;
+    name: string;
+    startedAt: string;
+    finishedAt?: string;
+    success: boolean;
+    tags?: string[];
+}
+
+export interface MissionPattern {
+    pattern: string[];
+    successRate: number;
+    averageDurationMs?: number;
+}
+
+export interface MissionShortcut {
+    name: string;
+    sequence: string[];
+    triggerCount: number;
+}
+
+export interface UserBehaviorMemory {
+    domains: DomainStat[];
+    skillPacks: SkillUsage[];
+    clickPatterns: ClickPattern[];
+    workflows: WorkflowPattern[];
+    timeOfDay: TimeBehavior[];
+}
+
+export interface AgentMemory {
+    successfulSelectors: SelectorStat[];
+    failedSelectors: SelectorStat[];
+    healedSelectors: SelectorStat[];
+    preferredRecoveryPaths: RecoveryPattern[];
+}
+
+export interface BrowserMemory {
+    pluginsLiked: UsageStat[];
+    panelsUsed: UsageStat[];
+    sidebarsPinned: string[];
+    customShortcuts: ShortcutPreference[];
+}
+
+export interface ContextualMemory {
+    keywords: KeywordAssociation[];
+    frequentTags: UsageStat[];
+    contentTopics: TopicStat[];
+}
+
+export interface MissionMemory {
+    pastMissions: MissionRecord[];
+    bestPatterns: MissionPattern[];
+    shortcuts: MissionShortcut[];
+}
+
+export interface MemoryStore {
+    userBehavior: UserBehaviorMemory;
+    agent: AgentMemory;
+    browser: BrowserMemory;
+    context: ContextualMemory;
+    missions: MissionMemory;
+    updatedAt: string;
+}
+
+export type MemoryEventType =
+    | 'command_executed'
+    | 'skill_pack_invoked'
+    | 'plugin_opened'
+    | 'popup_closed'
+    | 'sentinel_warning'
+    | 'shadow_mode_event'
+    | 'orchestrator_mission_start'
+    | 'orchestrator_mission_finish'
+    | 'vault_snapshot_viewed'
+    | 'vault_snapshot_saved';
+
+export interface MemoryEvent {
+    type: MemoryEventType;
+    timestamp: string;
+    payload: Record<string, any>;
+    context?: string;
+}
+
+export interface Recommendation {
+    actions: string[];
+    confidence: number;
+    reason: string;
+}
+
+export interface LearningInsights {
+    emergingHabits: string[];
+    weakSelectors: SelectorStat[];
+    strongSelectors: SelectorStat[];
+    deadWorkflows: WorkflowPattern[];
+    preferredPanels: string[];
+    bestPluginCombos: string[][];
+}

--- a/src/memory/privacy.ts
+++ b/src/memory/privacy.ts
@@ -1,0 +1,106 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { MemoryEventType } from './memoryTypes';
+
+export interface PrivacySettings {
+    privateMode: boolean;
+    disabledCategories: MemoryEventType[];
+    allowPHI: boolean;
+    encryptionKey?: string;
+}
+
+const DEFAULT_SETTINGS: PrivacySettings = {
+    privateMode: false,
+    disabledCategories: [],
+    allowPHI: false,
+    encryptionKey: process.env.MEMORY_SECRET,
+};
+
+const SENSITIVE_KEYS = ['password', 'token', 'secret', 'auth', 'ssn'];
+
+export class PrivacyManager {
+    private settings: PrivacySettings;
+
+    constructor(settings: Partial<PrivacySettings> = {}) {
+        this.settings = { ...DEFAULT_SETTINGS, ...settings };
+    }
+
+    public isEventAllowed(type: MemoryEventType): boolean {
+        if (this.settings.privateMode) return false;
+        return !this.settings.disabledCategories.includes(type);
+    }
+
+    public sanitizePayload<T extends Record<string, any>>(payload: T): T {
+        if (this.settings.allowPHI) return payload;
+        const clean: Record<string, any> = {};
+        Object.entries(payload).forEach(([key, value]) => {
+            if (SENSITIVE_KEYS.some((k) => key.toLowerCase().includes(k))) {
+                return;
+            }
+            clean[key] = value;
+        });
+        return clean as T;
+    }
+
+    public enablePrivateMode(): void {
+        this.settings.privateMode = true;
+    }
+
+    public disablePrivateMode(): void {
+        this.settings.privateMode = false;
+    }
+
+    public disableCategory(type: MemoryEventType): void {
+        if (!this.settings.disabledCategories.includes(type)) {
+            this.settings.disabledCategories.push(type);
+        }
+    }
+
+    public enableCategory(type: MemoryEventType): void {
+        this.settings.disabledCategories = this.settings.disabledCategories.filter((t) => t !== type);
+    }
+
+    public wipeMemory(filePath: string): void {
+        if (fs.existsSync(filePath)) {
+            fs.rmSync(filePath, { force: true });
+        }
+    }
+
+    public encrypt(data: string): string {
+        const key = this.getKey();
+        const iv = crypto.randomBytes(16);
+        const cipher = crypto.createCipheriv('aes-256-ctr', key, iv);
+        const encrypted = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+        return `${iv.toString('hex')}:${encrypted.toString('hex')}`;
+    }
+
+    public decrypt(payload: string): string {
+        const [ivHex, dataHex] = payload.split(':');
+        const iv = Buffer.from(ivHex, 'hex');
+        const key = this.getKey();
+        const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
+        const decrypted = Buffer.concat([decipher.update(Buffer.from(dataHex, 'hex')), decipher.final()]);
+        return decrypted.toString('utf8');
+    }
+
+    public saveSettings(filePath: string): void {
+        const payload = JSON.stringify(this.settings, null, 2);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, payload, 'utf8');
+    }
+
+    public loadSettings(filePath: string): PrivacySettings {
+        if (!fs.existsSync(filePath)) return this.settings;
+        const raw = fs.readFileSync(filePath, 'utf8');
+        this.settings = { ...this.settings, ...JSON.parse(raw) };
+        return this.settings;
+    }
+
+    private getKey(): Buffer {
+        const key = this.settings.encryptionKey || process.env.MEMORY_SECRET || 'default-local-memory-key';
+        return crypto.createHash('sha256').update(key).digest();
+    }
+}
+
+export const privacyManager = new PrivacyManager();

--- a/src/orchestrator/memoryAwarePlanner.ts
+++ b/src/orchestrator/memoryAwarePlanner.ts
@@ -1,0 +1,49 @@
+import { getMissionHistory, getMemoryStore } from '../memory/memoryEngine';
+import { MissionRecord, MissionShortcut } from '../memory/memoryTypes';
+
+export interface PlannerRecommendation {
+    shortcuts: MissionShortcut[];
+    defaultAgents: string[];
+    followUps: string[];
+}
+
+const deriveDefaultAgents = (missions: MissionRecord[]): string[] => {
+    const agentCounts: Record<string, number> = {};
+    missions.forEach((mission) => {
+        (mission.tags || []).forEach((tag) => {
+            agentCounts[tag] = (agentCounts[tag] || 0) + 1;
+        });
+    });
+    return Object.entries(agentCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([name]) => name);
+};
+
+const deriveFollowUps = (missions: MissionRecord[]): string[] => {
+    const suggestions = new Set<string>();
+    missions.forEach((mission) => {
+        if (mission.name.toLowerCase().includes('analytics')) {
+            suggestions.add('Offer video edit after analytics export');
+        }
+        if (mission.name.toLowerCase().includes('download')) {
+            suggestions.add('Suggest checksum verification');
+        }
+    });
+    return Array.from(suggestions);
+};
+
+export const buildMemoryAwarePlan = (): PlannerRecommendation => {
+    const missionMemory = getMissionHistory();
+    const defaults = deriveDefaultAgents(missionMemory.pastMissions);
+    return {
+        shortcuts: missionMemory.shortcuts,
+        defaultAgents: defaults,
+        followUps: deriveFollowUps(missionMemory.pastMissions),
+    };
+};
+
+export const suggestMissionSequence = (missionName: string): MissionShortcut | undefined => {
+    const missionMemory = getMemoryStore().missions;
+    return missionMemory.shortcuts.find((shortcut) => missionName.toLowerCase().includes(shortcut.name.toLowerCase()));
+};

--- a/src/personality/personalization.ts
+++ b/src/personality/personalization.ts
@@ -1,0 +1,94 @@
+import { getMemoryStore, recommendActions } from '../memory/memoryEngine';
+import { Recommendation } from '../memory/memoryTypes';
+
+export interface ToolbarLayout {
+    pinnedPlugins: string[];
+    prioritizedPanels: string[];
+    shortcuts: string[];
+}
+
+export interface WorkflowSuggestion {
+    title: string;
+    steps: string[];
+    reason: string;
+}
+
+export interface PersonalizationPlan {
+    toolbar: ToolbarLayout;
+    pluginSuggestions: string[];
+    highlightedFlows: WorkflowSuggestion[];
+    preloadSkillPacks: string[];
+    offlineVaults: string[];
+    continueWorkflow?: WorkflowSuggestion;
+    orchestratorHints: Recommendation;
+}
+
+const getTopItems = (items: { name: string; count: number }[], limit = 3): string[] =>
+    items
+        .sort((a, b) => b.count - a.count)
+        .slice(0, limit)
+        .map((item) => item.name);
+
+export const rearrangeToolbar = (): ToolbarLayout => {
+    const memory = getMemoryStore();
+    return {
+        pinnedPlugins: getTopItems(memory.browser.pluginsLiked, 5),
+        prioritizedPanels: getTopItems(memory.browser.panelsUsed, 4),
+        shortcuts: memory.browser.customShortcuts.sort((a, b) => b.frequency - a.frequency).map((item) => item.shortcut),
+    };
+};
+
+export const suggestPlugins = (): string[] => {
+    const memory = getMemoryStore();
+    const infrequent = memory.browser.pluginsLiked.filter((plugin) => plugin.count < 2).map((plugin) => plugin.name);
+    const trending = getTopItems(memory.browser.pluginsLiked, 3);
+    return [...new Set([...trending, ...infrequent])];
+};
+
+export const highlightFlows = (): WorkflowSuggestion[] => {
+    const memory = getMemoryStore();
+    return memory.userBehavior.workflows
+        .filter((wf) => wf.successRate > 0.6)
+        .sort((a, b) => b.successRate - a.successRate)
+        .slice(0, 3)
+        .map((wf) => ({
+            title: wf.name,
+            steps: ['Launch orchestrator', 'Auto-fill last arguments', 'Confirm'],
+            reason: `High success rate (${Math.round(wf.successRate * 100)}%)`,
+        }));
+};
+
+export const preloadSkillPacks = (): string[] => {
+    const memory = getMemoryStore();
+    const frequentDomains = getTopItems(memory.userBehavior.domains, 2);
+    return memory.userBehavior.skillPacks
+        .filter((skill) => skill.count > 1)
+        .map((skill) => skill.name)
+        .concat(frequentDomains.map((domain) => `domain:${domain}`));
+};
+
+export const preloadVaultPages = (): string[] => {
+    const memory = getMemoryStore();
+    return memory.context.frequentTags.filter((tag) => tag.count > 1).map((tag) => tag.name);
+};
+
+export const continueWorkflow = (): WorkflowSuggestion | undefined => {
+    const memory = getMemoryStore();
+    const recent = memory.userBehavior.workflows.sort((a, b) => (b.lastRun || '').localeCompare(a.lastRun || ''))[0];
+    if (!recent) return undefined;
+    return {
+        title: recent.name,
+        steps: ['Resume last page', 'Reload context', 'Offer previous plan'],
+        reason: 'Continue where you left off',
+    };
+};
+
+export const buildPersonalizationPlan = (context: string): PersonalizationPlan => ({
+    toolbar: rearrangeToolbar(),
+    pluginSuggestions: suggestPlugins(),
+    highlightedFlows: highlightFlows(),
+    preloadSkillPacks: preloadSkillPacks(),
+    offlineVaults: preloadVaultPages(),
+    continueWorkflow: continueWorkflow(),
+    orchestratorHints: recommendActions(context),
+});

--- a/tools/qa/memory-smoke.ts
+++ b/tools/qa/memory-smoke.ts
@@ -1,0 +1,36 @@
+import path from 'path';
+import { recordEvent, saveMemory, loadMemory, getBehaviorPatterns, recommendActions, getMissionHistory } from '../../src/memory/memoryEngine';
+import { privacyManager } from '../../src/memory/privacy';
+
+const memoryPath = path.join(process.cwd(), 'data', 'memory', 'memory.enc');
+
+async function run() {
+    console.log('Recording events...');
+    recordEvent({ type: 'command_executed', timestamp: new Date().toISOString(), payload: { domain: 'example.com', workflow: 'login', success: true } });
+    recordEvent({ type: 'skill_pack_invoked', timestamp: new Date().toISOString(), payload: { name: 'form-filler', domain: 'example.com' } });
+    recordEvent({ type: 'plugin_opened', timestamp: new Date().toISOString(), payload: { plugin: 'translator' } });
+    recordEvent({ type: 'orchestrator_mission_start', timestamp: new Date().toISOString(), payload: { missionId: '123', name: 'analytics-download', tags: ['downloader', 'analytics'] } });
+    recordEvent({ type: 'orchestrator_mission_finish', timestamp: new Date().toISOString(), payload: { missionId: '123', success: true } });
+
+    saveMemory();
+
+    console.log('Reloading memory...');
+    loadMemory();
+
+    const patterns = getBehaviorPatterns();
+    console.log('Emerging habits:', patterns.emergingHabits);
+
+    const recommendations = recommendActions('example context');
+    console.log('Recommended actions:', recommendations.actions);
+
+    const missions = getMissionHistory();
+    console.log('Mission history length:', missions.pastMissions.length);
+
+    console.log('Wiping memory...');
+    privacyManager.wipeMemory(memoryPath);
+}
+
+run().catch((error) => {
+    console.error('QA memory smoke failed', error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- introduce adaptive personal memory data models, engine, learning loop, and privacy controls
- add personalization layer, mission-aware planner, and developer memory dashboard
- document adaptive memory architecture and include QA smoke test for event recording

## Testing
- npm run qa:memory


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df8317f708324a8ba2f32b8486dc9)